### PR TITLE
Allow dashes in file name

### DIFF
--- a/pmtiles/loop.go
+++ b/pmtiles/loop.go
@@ -183,7 +183,7 @@ func (loop Loop) Get(path string) (int,map[string]string,[]byte) {
 		headers["Access-Control-Allow-Origin"] = loop.cors
 	}
 	start := time.Now()
-	rPath := regexp.MustCompile(`\/(?P<NAME>[A-Za-z0-9_]+)\/(?P<Z>\d+)\/(?P<X>\d+)\/(?P<Y>\d+)\.(?P<EXT>png|pbf|jpg)`)
+	rPath := regexp.MustCompile(`\/(?P<NAME>[-A-Za-z0-9_]+)\/(?P<Z>\d+)\/(?P<X>\d+)\/(?P<Y>\d+)\.(?P<EXT>png|pbf|jpg)`)
 	res := rPath.FindStringSubmatch(path)
 	misses := 0
 


### PR DESCRIPTION
... since they are allowed in object names for some providers, and otherwise we get 404 error.

Also it is quite hard to debug as there is no log at all in this case. Suggestions:
- Return 400 Bad Request instead of 404
- Log `Malformed URL "foo"`

Note: PR made in the browser, untested, and my first line of Go, if we can call it that :laughing: 