### PR TITLE
Return errors instead of triggering fatal errors in library code

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,7 +25,11 @@ func main() {
 
 	switch os.Args[1] {
 	case "show":
-		pmtiles.Show(logger, os.Args[2:])
+		err := pmtiles.Show(logger, os.Args[2:])
+
+		if err != nil {
+			logger.Fatalf("Failed to show database, %v", err)
+		}
 	case "serve":
 		serveCmd := flag.NewFlagSet("serve", flag.ExitOnError)
 		port := serveCmd.String("p", "8080", "port to serve on")
@@ -37,7 +41,12 @@ func main() {
 			logger.Println("USAGE: serve  [-p PORT] [-cors VALUE] LOCAL_PATH or https://BUCKET")
 			os.Exit(1)
 		}
-		loop := pmtiles.NewLoop(path, logger, *cacheSize, *cors)
+		loop, err := pmtiles.NewLoop(path, logger, *cacheSize, *cors)
+
+		if err != nil {
+			logger.Fatalf("Failed to create new loop, %v", err)
+		}
+
 		loop.Start()
 
 		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -83,9 +92,19 @@ func main() {
 		convertCmd.Parse(os.Args[2:])
 		path := convertCmd.Arg(0)
 		output := convertCmd.Arg(1)
-		pmtiles.Convert(logger, path, output)
+		err := pmtiles.Convert(logger, path, output)
+
+		if err != nil {
+			logger.Fatalf("Failed to convert %s, %v", path, err)
+		}
+
 	case "upload":
-		pmtiles.Upload(logger, os.Args[2:])
+		err := pmtiles.Upload(logger, os.Args[2:])
+
+		if err != nil {
+			logger.Fatalf("Failed to upload file, %v", err)
+		}
+
 	case "validate":
 		// pmtiles.Validate()
 	default:

--- a/pmtiles/convert_test.go
+++ b/pmtiles/convert_test.go
@@ -90,9 +90,9 @@ func TestV2UpgradeBarebones(t *testing.T) {
 
 func TestV2UpgradeStrings(t *testing.T) {
 	header, _, err := v2_to_header_json(map[string]interface{}{
-		"minzoom":     "0",
-		"maxzoom":     "14",
-		"bounds":      "-180.0,-85,178,83",
+		"minzoom": "0",
+		"maxzoom": "14",
+		"bounds":  "-180.0,-85,178,83",
 	}, []byte{0x1f, 0x8b, 0x0, 0x0})
 	if err != nil {
 		t.Fatalf("parsing error %s", err)

--- a/pmtiles/directory_test.go
+++ b/pmtiles/directory_test.go
@@ -2,9 +2,9 @@ package pmtiles
 
 import (
 	"bytes"
+	"github.com/stretchr/testify/assert"
 	"math/rand"
 	"testing"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDirectoryRoundtrip(t *testing.T) {
@@ -188,58 +188,58 @@ func TestOptimizeDirectories(t *testing.T) {
 }
 
 func TestFindTileMissing(t *testing.T) {
-	entries := make([]EntryV3,0)
-	_, ok := find_tile(entries,0)
+	entries := make([]EntryV3, 0)
+	_, ok := find_tile(entries, 0)
 	if ok {
 		t.Fatalf("Expected not ok")
 	}
 }
 
 func TestFindTileFirstEntry(t *testing.T) {
-	entries := []EntryV3{{TileId:100, Offset: 1, Length: 1, RunLength:1}}
-	entry, ok := find_tile(entries,100)
-	assert.Equal(t,true,ok)
-	assert.Equal(t,uint64(1),entry.Offset)
-	assert.Equal(t,uint32(1),entry.Length)
-	_, ok = find_tile(entries,101)
-	assert.Equal(t,false,ok)
+	entries := []EntryV3{{TileId: 100, Offset: 1, Length: 1, RunLength: 1}}
+	entry, ok := find_tile(entries, 100)
+	assert.Equal(t, true, ok)
+	assert.Equal(t, uint64(1), entry.Offset)
+	assert.Equal(t, uint32(1), entry.Length)
+	_, ok = find_tile(entries, 101)
+	assert.Equal(t, false, ok)
 }
 
 func TestFindTileMultipleEntries(t *testing.T) {
 	entries := []EntryV3{
-		{TileId:100, Offset: 1, Length: 1, RunLength:2},
+		{TileId: 100, Offset: 1, Length: 1, RunLength: 2},
 	}
-	entry, ok := find_tile(entries,101)
-	assert.Equal(t,true,ok)
-	assert.Equal(t,uint64(1),entry.Offset)
-	assert.Equal(t,uint32(1),entry.Length)
+	entry, ok := find_tile(entries, 101)
+	assert.Equal(t, true, ok)
+	assert.Equal(t, uint64(1), entry.Offset)
+	assert.Equal(t, uint32(1), entry.Length)
 
 	entries = []EntryV3{
-		{TileId:100, Offset: 1, Length: 1, RunLength:1},
-		{TileId:150, Offset: 2, Length: 2, RunLength:2},
+		{TileId: 100, Offset: 1, Length: 1, RunLength: 1},
+		{TileId: 150, Offset: 2, Length: 2, RunLength: 2},
 	}
-	entry, ok = find_tile(entries,151)
-	assert.Equal(t,true,ok)
-	assert.Equal(t,uint64(2),entry.Offset)
-	assert.Equal(t,uint32(2),entry.Length)
+	entry, ok = find_tile(entries, 151)
+	assert.Equal(t, true, ok)
+	assert.Equal(t, uint64(2), entry.Offset)
+	assert.Equal(t, uint32(2), entry.Length)
 
 	entries = []EntryV3{
-		{TileId:50, Offset: 1, Length: 1, RunLength:2},
-		{TileId:100, Offset: 2, Length: 2, RunLength:1},
-		{TileId:150, Offset: 3, Length: 3, RunLength:1},
+		{TileId: 50, Offset: 1, Length: 1, RunLength: 2},
+		{TileId: 100, Offset: 2, Length: 2, RunLength: 1},
+		{TileId: 150, Offset: 3, Length: 3, RunLength: 1},
 	}
-	entry, ok = find_tile(entries,51)
-	assert.Equal(t,true,ok)
-	assert.Equal(t,uint64(1),entry.Offset)
-	assert.Equal(t,uint32(1),entry.Length)
+	entry, ok = find_tile(entries, 51)
+	assert.Equal(t, true, ok)
+	assert.Equal(t, uint64(1), entry.Offset)
+	assert.Equal(t, uint32(1), entry.Length)
 }
 
 func TestFindTileLeafSearch(t *testing.T) {
 	entries := []EntryV3{
-		{TileId:100, Offset: 1, Length: 1, RunLength:0},
+		{TileId: 100, Offset: 1, Length: 1, RunLength: 0},
 	}
-	entry, ok := find_tile(entries,150)
-	assert.Equal(t,true,ok)
-	assert.Equal(t,uint64(1),entry.Offset)
-	assert.Equal(t,uint32(1),entry.Length)
+	entry, ok := find_tile(entries, 150)
+	assert.Equal(t, true, ok)
+	assert.Equal(t, uint64(1), entry.Offset)
+	assert.Equal(t, uint32(1), entry.Length)
 }

--- a/pmtiles/readerv2_test.go
+++ b/pmtiles/readerv2_test.go
@@ -5,12 +5,12 @@ import (
 )
 
 func TestUint24(t *testing.T) {
-	b := []byte{255,255,255}
+	b := []byte{255, 255, 255}
 	result := readUint24(b)
 	if result != 16777215 {
 		t.Errorf("result did not match, was %d", result)
 	}
-	b = []byte{255,0,0}
+	b = []byte{255, 0, 0}
 	result = readUint24(b)
 	if result != 255 {
 		t.Errorf("result did not match, was %d", result)
@@ -18,12 +18,12 @@ func TestUint24(t *testing.T) {
 }
 
 func TestUint48(t *testing.T) {
-	b := []byte{255,255,255,255,255,255}
+	b := []byte{255, 255, 255, 255, 255, 255}
 	result := readUint48(b)
 	if result != 281474976710655 {
 		t.Errorf("result did not match, was %d", result)
 	}
-	b = []byte{255,0,0,0,0,0}
+	b = []byte{255, 0, 0, 0, 0, 0}
 	result = readUint48(b)
 	if result != 255 {
 		t.Errorf("result did not match, was %d", result)
@@ -31,9 +31,9 @@ func TestUint48(t *testing.T) {
 }
 
 func TestGetParentTile(t *testing.T) {
-	a := Zxy{Z:8,X:125,Y:69}
-	result := GetParentTile(a,7)
-	if (result != Zxy{Z:7,X:62,Y:34}) {
+	a := Zxy{Z: 8, X: 125, Y: 69}
+	result := GetParentTile(a, 7)
+	if (result != Zxy{Z: 7, X: 62, Y: 34}) {
 		t.Errorf("result did not match, was %d", result)
 	}
 }

--- a/pmtiles/show.go
+++ b/pmtiles/show.go
@@ -10,7 +10,7 @@ import (
 	"log"
 )
 
-func Show(logger *log.Logger, args []string) {
+func Show(logger *log.Logger, args []string) error {
 	cmd := flag.NewFlagSet("upload", flag.ExitOnError)
 	cmd.Parse(args)
 	bucketURL := cmd.Arg(0)
@@ -19,18 +19,18 @@ func Show(logger *log.Logger, args []string) {
 	ctx := context.Background()
 	bucket, err := blob.OpenBucket(ctx, bucketURL)
 	if err != nil {
-		logger.Fatal(err)
+		return fmt.Errorf("Failed to open bucket for %s, %w", bucketURL, err)
 	}
 	defer bucket.Close()
 
 	r, err := bucket.NewRangeReader(ctx, file, 0, 16384, nil)
 
 	if err != nil {
-		logger.Fatal(err)
+		return fmt.Errorf("Failed to create range reader for %s, %w", file, err)
 	}
 	b, err := io.ReadAll(r)
 	if err != nil {
-		logger.Fatal(err)
+		return fmt.Errorf("Failed to read %s, %w", file, err)
 	}
 	r.Close()
 
@@ -64,4 +64,6 @@ func Show(logger *log.Logger, args []string) {
 	// for _, entry := range entries {
 	// 	fmt.Println(entry)
 	// }
+
+	return nil
 }

--- a/pmtiles/subpyramid_test.go
+++ b/pmtiles/subpyramid_test.go
@@ -5,24 +5,24 @@ import (
 )
 
 func TestPointToTile(t *testing.T) {
-	result := PointToTile(4,0,0)
-	if (result != Zxy{4,8,8}) {
+	result := PointToTile(4, 0, 0)
+	if (result != Zxy{4, 8, 8}) {
 		t.Errorf("result did not match, was %d", result)
 	}
-	result = PointToTile(4,-180,-85)
-	if (result != Zxy{4,0,15}) {
+	result = PointToTile(4, -180, -85)
+	if (result != Zxy{4, 0, 15}) {
 		t.Errorf("result did not match, was %d", result)
 	}
-	result = PointToTile(4,-180,85)
-	if (result != Zxy{4,0,0}) {
+	result = PointToTile(4, -180, 85)
+	if (result != Zxy{4, 0, 0}) {
 		t.Errorf("result did not match, was %d", result)
 	}
-	result = PointToTile(4,179.999,-85)
-	if (result != Zxy{4,15,15}) {
+	result = PointToTile(4, 179.999, -85)
+	if (result != Zxy{4, 15, 15}) {
 		t.Errorf("result did not match, was %d", result)
 	}
-	result = PointToTile(4,179.999,85)
-	if (result != Zxy{4,15,0}) {
+	result = PointToTile(4, 179.999, 85)
+	if (result != Zxy{4, 15, 0}) {
 		t.Errorf("result did not match, was %d", result)
 	}
 }


### PR DESCRIPTION
This PR replaces all the calls to `log.Fatal` or `panic` in the `pmtiles` package libraries with `error` responses. The `main.go` tool has been updated accordingly. This allows the `pmtiles` package to be used by other code without having to trap fatal errors.