### PR TITLE
Use go v1.18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,5 +9,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.17.0'
+          go-version: '^1.18.0'
       - run: go test ./pmtiles

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/protomaps/go-pmtiles
 
-go 1.17
+go 1.18
 
 require (
 	github.com/RoaringBitmap/roaring v1.2.1


### PR DESCRIPTION
Bumps the golang version from v1.17 (which did not work I think) to v1.18.
