### PR TITLE
mbtiles convert: default bounds to world if bounds metadata missing [#60]

### DIFF
--- a/pmtiles/convert.go
+++ b/pmtiles/convert.go
@@ -305,6 +305,10 @@ func ConvertMbtiles(logger *log.Logger, input string, output string, deduplicate
 		}
 	}
 
+	if tileset.GetCardinality() == 0 {
+		return fmt.Errorf("No tiles in MBTiles archive.")
+	}
+
 	logger.Println("Pass 2: writing tiles")
 	resolver := NewResolver(deduplicate, header.TileType == Mvt)
 	{

--- a/pmtiles/convert_test.go
+++ b/pmtiles/convert_test.go
@@ -175,3 +175,38 @@ func TestMbtiles(t *testing.T) {
 	_, ok = json_metadata["tilestats"]
 	assert.True(t, ok)
 }
+
+func TestMbtilesMissingBoundsCenter(t *testing.T) {
+	header, _, err := mbtiles_to_header_json([]string{
+		"name", "test_name",
+		"format", "pbf",
+		"attribution", "<div>abc</div>",
+		"description", "a description",
+		"type", "overlay",
+		"version", "1",
+		"json", "{\"vector_layers\":[{\"abc\":123}],\"tilestats\":{\"def\":456}}",
+		"compression", "gzip",
+	})
+	assert.Nil(t,err)
+	assert.Equal(t,int32(-180*10000000), header.MinLonE7)
+	assert.Equal(t,int32(-85*10000000), header.MinLatE7)
+	assert.Equal(t,int32(180*10000000), header.MaxLonE7)
+	assert.Equal(t,int32(85*10000000), header.MaxLatE7)
+	assert.Equal(t,int32(0), header.CenterLonE7)
+	assert.Equal(t,int32(0), header.CenterLatE7)
+}
+
+func TestMbtilesDegenerateBounds(t *testing.T) {
+	_, _, err := mbtiles_to_header_json([]string{
+		"name", "test_name",
+		"format", "pbf",
+		"bounds", "0,0,0,0",
+		"attribution", "<div>abc</div>",
+		"description", "a description",
+		"type", "overlay",
+		"version", "1",
+		"json", "{\"vector_layers\":[{\"abc\":123}],\"tilestats\":{\"def\":456}}",
+		"compression", "gzip",
+	})
+	assert.NotNil(t,err)
+}


### PR DESCRIPTION
* error out if bounds is degenerate (zero or less area)