### PR TITLE
Don't force aws sdk v2 for s3 buckets [#112]

### DIFF
--- a/pmtiles/bucket.go
+++ b/pmtiles/bucket.go
@@ -97,17 +97,6 @@ func NormalizeBucketKey(bucket string, prefix string, key string) (string, strin
 		}
 	}
 
-	if strings.HasPrefix(bucket, "s3") {
-		u, err := url.Parse(bucket)
-		if err != nil {
-			fmt.Println("Error parsing URL:", err)
-			return "", "", err
-		}
-		values := u.Query()
-		values.Set("awssdk", "v2")
-		u.RawQuery = values.Encode()
-		return u.String(), key, nil
-	}
 	return bucket, key, nil
 }
 

--- a/pmtiles/bucket_test.go
+++ b/pmtiles/bucket_test.go
@@ -29,12 +29,6 @@ func TestNormalizeHttp(t *testing.T) {
 	assert.Equal(t, "http://example.com/foo", bucket)
 }
 
-func TestNormalizeAwsSdkVersion(t *testing.T) {
-	bucket, key, _ := NormalizeBucketKey("s3://mybucket?awssdk=v1&endpoint=https://foo.bar", "", "abc")
-	assert.Equal(t, "abc", key)
-	assert.Equal(t, "s3://mybucket?awssdk=v2&endpoint=https%3A%2F%2Ffoo.bar", bucket)
-}
-
 func TestNormalizePathPrefixServer(t *testing.T) {
 	bucket, key, _ := NormalizeBucketKey("", "../foo", "")
 	assert.Equal(t, "", key)


### PR DESCRIPTION
* this is to allow sdk v1 query params like s3ForcePathStyle, to work with Minio, etc.