### PR TITLE
Implement native file bucket with change detection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: test
 
-on: [push]
+on:
+  pull_request:
+    branches:
+      - "main"
 
 jobs:
   test:
@@ -12,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.21.0'
+          go-version: "^1.21.0"
       - run: go test ./pmtiles
   fmt_vet_lint:
     runs-on: ubuntu-latest
@@ -20,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.21.0'
+          go-version: "^1.21.0"
       - run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi
       - run: go vet caddy/pmtiles_proxy.go
       - run: go vet main.go

--- a/pmtiles/bucket.go
+++ b/pmtiles/bucket.go
@@ -70,7 +70,6 @@ func (m mockBucket) NewRangeReaderEtag(_ context.Context, key string, offset int
 // FileBucket is a bucket backed by a directory on disk
 type FileBucket struct {
 	path string
-	file *os.File
 }
 
 func (b FileBucket) NewRangeReader(ctx context.Context, key string, offset, length int64) (io.ReadCloser, error) {
@@ -246,7 +245,7 @@ func OpenBucket(ctx context.Context, bucketURL string, bucketPrefix string) (Buc
 		if err != nil {
 			return nil, err
 		}
-		bucket := FileBucket{url.Path, nil}
+		bucket := FileBucket{url.Path}
 		return bucket, nil
 	}
 	bucket, err := blob.OpenBucket(ctx, bucketURL)

--- a/pmtiles/bucket.go
+++ b/pmtiles/bucket.go
@@ -78,7 +78,7 @@ func (b FileBucket) NewRangeReader(ctx context.Context, key string, offset, leng
 }
 
 func (b FileBucket) NewRangeReaderEtag(ctx context.Context, key string, offset, length int64, etag string) (io.ReadCloser, string, error) {
-	name := b.path + string(os.PathSeparator) + key
+	name := filepath.Join(b.path, key)
 	file, err := os.Open(name)
 	defer file.Close()
 	if err != nil {

--- a/pmtiles/bucket.go
+++ b/pmtiles/bucket.go
@@ -77,7 +77,7 @@ func (b FileBucket) NewRangeReader(ctx context.Context, key string, offset, leng
 	return body, err
 }
 
-func (b FileBucket) NewRangeReaderEtag(ctx context.Context, key string, offset, length int64, etag string) (io.ReadCloser, string, error) {
+func (b FileBucket) NewRangeReaderEtag(_ context.Context, key string, offset, length int64, etag string) (io.ReadCloser, string, error) {
 	name := filepath.Join(b.path, key)
 	file, err := os.Open(name)
 	defer file.Close()

--- a/pmtiles/bucket.go
+++ b/pmtiles/bucket.go
@@ -241,11 +241,12 @@ func OpenBucket(ctx context.Context, bucketURL string, bucketPrefix string) (Buc
 		return bucket, nil
 	}
 	if strings.HasPrefix(bucketURL, "file") {
-		url, err := url.ParseRequestURI(bucketURL)
-		if err != nil {
-			return nil, err
+		fileprotocol := "file://"
+		if string(os.PathSeparator) != "/" {
+			fileprotocol += "/"
 		}
-		bucket := FileBucket{url.Path}
+		path := strings.Replace(bucketURL, fileprotocol, "", 1)
+		bucket := FileBucket{filepath.FromSlash(path)}
 		return bucket, nil
 	}
 	bucket, err := blob.OpenBucket(ctx, bucketURL)

--- a/pmtiles/bucket_test.go
+++ b/pmtiles/bucket_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -118,14 +119,14 @@ func TestHttpBucketRequestRequestEtagFailed(t *testing.T) {
 }
 
 func TestFileBucketReplace(t *testing.T) {
-	dir := t.TempDir() + string(os.PathSeparator)
-	bucketURL, _, err := NormalizeBucketKey("", dir, "")
+	tmp := t.TempDir()
+	bucketURL, _, err := NormalizeBucketKey("", tmp, "")
 	assert.Nil(t, err)
 	fmt.Println(bucketURL)
 	bucket, err := OpenBucket(context.Background(), bucketURL, "")
 	assert.Nil(t, err)
 	assert.NotNil(t, bucket)
-	assert.Nil(t, os.WriteFile(dir+"archive.pmtiles", []byte{1, 2, 3}, 0666))
+	assert.Nil(t, os.WriteFile(filepath.Join(tmp, "archive.pmtiles"), []byte{1, 2, 3}, 0666))
 
 	// first read from file
 	reader, etag1, err := bucket.NewRangeReaderEtag(context.Background(), "archive.pmtiles", 1, 1, "")
@@ -135,7 +136,7 @@ func TestFileBucketReplace(t *testing.T) {
 	assert.Equal(t, []byte{2}, data)
 
 	// change file, verify etag changes
-	assert.Nil(t, os.WriteFile(dir+"archive.pmtiles", []byte{4, 5, 6, 7}, 0666))
+	assert.Nil(t, os.WriteFile(filepath.Join(tmp, "archive.pmtiles"), []byte{4, 5, 6, 7}, 0666))
 	reader, etag2, err := bucket.NewRangeReaderEtag(context.Background(), "archive.pmtiles", 1, 1, "")
 	assert.Nil(t, err)
 	data, err = io.ReadAll(reader)
@@ -149,17 +150,17 @@ func TestFileBucketReplace(t *testing.T) {
 }
 
 func TestFileBucketRename(t *testing.T) {
-	dir := t.TempDir() + string(os.PathSeparator)
-	assert.Nil(t, os.WriteFile(dir+"archive.pmtiles", []byte{1, 2, 3}, 0666))
-	assert.Nil(t, os.WriteFile(dir+"archive2.pmtiles", []byte{4, 5, 6, 7}, 0666))
+	tmp := t.TempDir()
+	assert.Nil(t, os.WriteFile(filepath.Join(tmp, "archive.pmtiles"), []byte{1, 2, 3}, 0666))
+	assert.Nil(t, os.WriteFile(filepath.Join(tmp, "archive2.pmtiles"), []byte{4, 5, 6, 7}, 0666))
 
-	bucketURL, _, err := NormalizeBucketKey("", dir, "")
+	bucketURL, _, err := NormalizeBucketKey("", tmp, "")
 	assert.Nil(t, err)
 	fmt.Println(bucketURL)
 	bucket, err := OpenBucket(context.Background(), bucketURL, "")
 	assert.Nil(t, err)
 	assert.NotNil(t, bucket)
-	assert.Nil(t, os.WriteFile(dir+"archive.pmtiles", []byte{1, 2, 3}, 0666))
+	assert.Nil(t, os.WriteFile(filepath.Join(tmp, "archive.pmtiles"), []byte{1, 2, 3}, 0666))
 
 	// first read from file
 	reader, etag1, err := bucket.NewRangeReaderEtag(context.Background(), "archive.pmtiles", 1, 1, "")
@@ -169,8 +170,8 @@ func TestFileBucketRename(t *testing.T) {
 	assert.Equal(t, []byte{2}, data)
 
 	// change file, verify etag changes
-	os.Rename(dir+"archive.pmtiles", dir+"archive3.pmtiles")
-	os.Rename(dir+"archive2.pmtiles", dir+"archive.pmtiles")
+	os.Rename(filepath.Join(tmp, "archive.pmtiles"), filepath.Join(tmp, "archive3.pmtiles"))
+	os.Rename(filepath.Join(tmp, "archive2.pmtiles"), filepath.Join(tmp, "archive.pmtiles"))
 	reader, etag2, err := bucket.NewRangeReaderEtag(context.Background(), "archive.pmtiles", 1, 1, "")
 	assert.Nil(t, err)
 	data, err = io.ReadAll(reader)

--- a/pmtiles/bucket_test.go
+++ b/pmtiles/bucket_test.go
@@ -118,14 +118,14 @@ func TestHttpBucketRequestRequestEtagFailed(t *testing.T) {
 }
 
 func TestFileBucketReplace(t *testing.T) {
-	dir := t.TempDir()
+	dir := t.TempDir() + string(os.PathSeparator)
 	bucketURL, _, err := NormalizeBucketKey("", dir, "")
 	assert.Nil(t, err)
 	fmt.Println(bucketURL)
 	bucket, err := OpenBucket(context.Background(), bucketURL, "")
 	assert.Nil(t, err)
 	assert.NotNil(t, bucket)
-	assert.Nil(t, os.WriteFile(dir+"/archive.pmtiles", []byte{1, 2, 3}, 0666))
+	assert.Nil(t, os.WriteFile(dir+"archive.pmtiles", []byte{1, 2, 3}, 0666))
 
 	// first read from file
 	reader, etag1, err := bucket.NewRangeReaderEtag(context.Background(), "archive.pmtiles", 1, 1, "")
@@ -135,7 +135,7 @@ func TestFileBucketReplace(t *testing.T) {
 	assert.Equal(t, []byte{2}, data)
 
 	// change file, verify etag changes
-	assert.Nil(t, os.WriteFile(dir+"/archive.pmtiles", []byte{4, 5, 6, 7}, 0666))
+	assert.Nil(t, os.WriteFile(dir+"archive.pmtiles", []byte{4, 5, 6, 7}, 0666))
 	reader, etag2, err := bucket.NewRangeReaderEtag(context.Background(), "archive.pmtiles", 1, 1, "")
 	assert.Nil(t, err)
 	data, err = io.ReadAll(reader)
@@ -149,9 +149,9 @@ func TestFileBucketReplace(t *testing.T) {
 }
 
 func TestFileBucketRename(t *testing.T) {
-	dir := t.TempDir()
-	assert.Nil(t, os.WriteFile(dir+"/archive.pmtiles", []byte{1, 2, 3}, 0666))
-	assert.Nil(t, os.WriteFile(dir+"/archive2.pmtiles", []byte{4, 5, 6, 7}, 0666))
+	dir := t.TempDir() + string(os.PathSeparator)
+	assert.Nil(t, os.WriteFile(dir+"archive.pmtiles", []byte{1, 2, 3}, 0666))
+	assert.Nil(t, os.WriteFile(dir+"archive2.pmtiles", []byte{4, 5, 6, 7}, 0666))
 
 	bucketURL, _, err := NormalizeBucketKey("", dir, "")
 	assert.Nil(t, err)
@@ -159,7 +159,7 @@ func TestFileBucketRename(t *testing.T) {
 	bucket, err := OpenBucket(context.Background(), bucketURL, "")
 	assert.Nil(t, err)
 	assert.NotNil(t, bucket)
-	assert.Nil(t, os.WriteFile(dir+"/archive.pmtiles", []byte{1, 2, 3}, 0666))
+	assert.Nil(t, os.WriteFile(dir+"archive.pmtiles", []byte{1, 2, 3}, 0666))
 
 	// first read from file
 	reader, etag1, err := bucket.NewRangeReaderEtag(context.Background(), "archive.pmtiles", 1, 1, "")
@@ -169,8 +169,8 @@ func TestFileBucketRename(t *testing.T) {
 	assert.Equal(t, []byte{2}, data)
 
 	// change file, verify etag changes
-	os.Rename(dir+"/archive.pmtiles", dir+"/archive3.pmtiles")
-	os.Rename(dir+"/archive2.pmtiles", dir+"/archive.pmtiles")
+	os.Rename(dir+"archive.pmtiles", dir+"archive3.pmtiles")
+	os.Rename(dir+"archive2.pmtiles", dir+"archive.pmtiles")
 	reader, etag2, err := bucket.NewRangeReaderEtag(context.Background(), "archive.pmtiles", 1, 1, "")
 	assert.Nil(t, err)
 	data, err = io.ReadAll(reader)

--- a/pmtiles/bucket_test.go
+++ b/pmtiles/bucket_test.go
@@ -135,7 +135,7 @@ func TestFileBucketReplace(t *testing.T) {
 	assert.Equal(t, []byte{2}, data)
 
 	// change file, verify etag changes
-	assert.Nil(t, os.WriteFile(dir+"/archive.pmtiles", []byte{4, 5, 6}, 0666))
+	assert.Nil(t, os.WriteFile(dir+"/archive.pmtiles", []byte{4, 5, 6, 7}, 0666))
 	reader, etag2, err := bucket.NewRangeReaderEtag(context.Background(), "archive.pmtiles", 1, 1, "")
 	assert.Nil(t, err)
 	data, err = io.ReadAll(reader)
@@ -151,7 +151,7 @@ func TestFileBucketReplace(t *testing.T) {
 func TestFileBucketRename(t *testing.T) {
 	dir := t.TempDir()
 	assert.Nil(t, os.WriteFile(dir+"/archive.pmtiles", []byte{1, 2, 3}, 0666))
-	assert.Nil(t, os.WriteFile(dir+"/archive2.pmtiles", []byte{4, 5, 6}, 0666))
+	assert.Nil(t, os.WriteFile(dir+"/archive2.pmtiles", []byte{4, 5, 6, 7}, 0666))
 
 	bucketURL, _, err := NormalizeBucketKey("", dir, "")
 	assert.Nil(t, err)


### PR DESCRIPTION
Move `file://` url handling to a dedicated implementation instead of using gocloud. Also made it detect file changes so that the server will purge its cache when the file changes.