### PR TITLE
Set etag on pmtiles serve responses

### DIFF
--- a/caddy/pmtiles_proxy.go
+++ b/caddy/pmtiles_proxy.go
@@ -2,6 +2,12 @@ package caddy
 
 import (
 	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
@@ -12,11 +18,6 @@ import (
 	_ "gocloud.dev/blob/fileblob"
 	_ "gocloud.dev/blob/gcsblob"
 	_ "gocloud.dev/blob/s3blob"
-	"io"
-	"log"
-	"net/http"
-	"strconv"
-	"time"
 )
 
 func init() {
@@ -29,6 +30,7 @@ type Middleware struct {
 	Bucket    string `json:"bucket"`
 	CacheSize int    `json:"cache_size"`
 	PublicURL string `json:"public_url"`
+	TileEtag  bool   `json:"tile_etag"`
 	logger    *zap.Logger
 	server    *pmtiles.Server
 }
@@ -45,7 +47,7 @@ func (m *Middleware) Provision(ctx caddy.Context) error {
 	m.logger = ctx.Logger()
 	logger := log.New(io.Discard, "", log.Ldate)
 	prefix := "." // serve only the root of the bucket for now, at the root route of Caddyfile
-	server, err := pmtiles.NewServer(m.Bucket, prefix, logger, m.CacheSize, "", m.PublicURL)
+	server, err := pmtiles.NewServer(m.Bucket, prefix, logger, m.CacheSize, "", m.PublicURL, m.TileEtag)
 	if err != nil {
 		return err
 	}

--- a/caddy/pmtiles_proxy.go
+++ b/caddy/pmtiles_proxy.go
@@ -30,7 +30,6 @@ type Middleware struct {
 	Bucket    string `json:"bucket"`
 	CacheSize int    `json:"cache_size"`
 	PublicURL string `json:"public_url"`
-	TileEtag  bool   `json:"tile_etag"`
 	logger    *zap.Logger
 	server    *pmtiles.Server
 }
@@ -47,7 +46,7 @@ func (m *Middleware) Provision(ctx caddy.Context) error {
 	m.logger = ctx.Logger()
 	logger := log.New(io.Discard, "", log.Ldate)
 	prefix := "." // serve only the root of the bucket for now, at the root route of Caddyfile
-	server, err := pmtiles.NewServer(m.Bucket, prefix, logger, m.CacheSize, "", m.PublicURL, m.TileEtag)
+	server, err := pmtiles.NewServer(m.Bucket, prefix, logger, m.CacheSize, "", m.PublicURL)
 	if err != nil {
 		return err
 	}
@@ -96,12 +95,6 @@ func (m *Middleware) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				if !d.Args(&m.PublicURL) {
 					return d.ArgErr()
 				}
-			case "tile_etag":
-				var tileEtag string
-				if !d.Args(&tileEtag) {
-					return d.ArgErr()
-				}
-				m.TileEtag = tileEtag == "true"
 			}
 		}
 	}

--- a/caddy/pmtiles_proxy.go
+++ b/caddy/pmtiles_proxy.go
@@ -1,6 +1,7 @@
 package caddy
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"log"
@@ -72,8 +73,12 @@ func (m Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 	for k, v := range headers {
 		w.Header().Set(k, v)
 	}
-	w.WriteHeader(statusCode)
-	w.Write(body)
+	if statusCode == 200 {
+		http.ServeContent(w, r, "", time.UnixMilli(0), bytes.NewReader(body))
+	} else {
+		w.WriteHeader(statusCode)
+		w.Write(body)
+	}
 	m.logger.Info("response", zap.Int("status", statusCode), zap.String("path", r.URL.Path), zap.Duration("duration", time.Since(start)))
 
 	return next.ServeHTTP(w, r)

--- a/caddy/pmtiles_proxy.go
+++ b/caddy/pmtiles_proxy.go
@@ -106,6 +106,12 @@ func (m *Middleware) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				if !d.Args(&m.PublicURL) {
 					return d.ArgErr()
 				}
+			case "tile_etag":
+				var tileEtag string
+				if !d.Args(&tileEtag) {
+					return d.ArgErr()
+				}
+				m.TileEtag = tileEtag == "true"
 			}
 		}
 	}

--- a/caddy/pmtiles_proxy.go
+++ b/caddy/pmtiles_proxy.go
@@ -1,7 +1,6 @@
 package caddy
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"log"
@@ -69,16 +68,7 @@ func (m *Middleware) Validate() error {
 
 func (m Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
 	start := time.Now()
-	statusCode, headers, body := m.server.Get(r.Context(), r.URL.Path)
-	for k, v := range headers {
-		w.Header().Set(k, v)
-	}
-	if statusCode == 200 {
-		http.ServeContent(w, r, "", time.UnixMilli(0), bytes.NewReader(body))
-	} else {
-		w.WriteHeader(statusCode)
-		w.Write(body)
-	}
+	statusCode := m.server.ServeHTTP(w, r)
 	m.logger.Info("response", zap.Int("status", statusCode), zap.String("path", r.URL.Path), zap.Duration("duration", time.Since(start)))
 
 	return next.ServeHTTP(w, r)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/alecthomas/kong v0.8.0
 	github.com/aws/aws-sdk-go v1.45.12
 	github.com/caddyserver/caddy/v2 v2.7.5
+	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/paulmach/orb v0.10.0
 	github.com/prometheus/client_golang v1.18.0
@@ -62,7 +63,6 @@ require (
 	github.com/bits-and-blooms/bitset v1.2.0 // indirect
 	github.com/caddyserver/certmagic v0.19.2 // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
-	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/main.go
+++ b/main.go
@@ -88,7 +88,6 @@ var cli struct {
 		CacheSize int    `default:"64" help:"Size of cache in Megabytes."`
 		Bucket    string `help:"Remote bucket"`
 		PublicURL string `help:"Public base URL of tile endpoint for TileJSON e.g. https://example.com/tiles/"`
-		TileEtag  bool   `help:"Generate etag for each tile instead of using archive etag"`
 	} `cmd:"" help:"Run an HTTP proxy server for Z/X/Y tiles."`
 
 	Download struct {
@@ -131,7 +130,7 @@ func main() {
 			logger.Fatalf("Failed to show tile, %v", err)
 		}
 	case "serve <path>":
-		server, err := pmtiles.NewServer(cli.Serve.Bucket, cli.Serve.Path, logger, cli.Serve.CacheSize, cli.Serve.Cors, cli.Serve.PublicURL, cli.Serve.TileEtag)
+		server, err := pmtiles.NewServer(cli.Serve.Bucket, cli.Serve.Path, logger, cli.Serve.CacheSize, cli.Serve.Cors, cli.Serve.PublicURL)
 
 		if err != nil {
 			logger.Fatalf("Failed to create new server, %v", err)

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"log"
 	"net/http"
@@ -142,22 +141,7 @@ func main() {
 
 		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
-			statusCode, headers, body := server.Get(r.Context(), r.URL.Path)
-			for k, v := range headers {
-				w.Header().Set(k, v)
-			}
-			if statusCode == 200 {
-				// handle if-match, if-none-match request headers based on response etag
-				http.ServeContent(
-					w, r,
-					"",                // name used to infer content-type, but we've already set that
-					time.UnixMilli(0), // ignore setting last-modified time and handling if-modified-since headers
-					bytes.NewReader(body),
-				)
-			} else {
-				w.WriteHeader(statusCode)
-				w.Write(body)
-			}
+			statusCode := server.ServeHTTP(w, r)
 			logger.Printf("served %d %s in %s", statusCode, r.URL.Path, time.Since(start))
 		})
 

--- a/pmtiles/server.go
+++ b/pmtiles/server.go
@@ -56,9 +56,6 @@ type Server struct {
 	tileEtag  bool
 }
 
-var emptyData = make([]byte, 0)
-var emptyEtag = generateEtag(emptyData)
-
 // NewServer creates a new pmtiles HTTP server.
 func NewServer(bucketURL string, prefix string, logger *log.Logger, cacheSize int, cors string, publicURL string, tileEtag bool) (*Server, error) {
 

--- a/pmtiles/server_test.go
+++ b/pmtiles/server_test.go
@@ -108,8 +108,12 @@ func fakeArchive(t *testing.T, header HeaderV3, metadata map[string]interface{},
 }
 
 func newServer(t *testing.T) (mockBucket, *Server) {
+	return newServerWithTileEtags(t, false)
+}
+
+func newServerWithTileEtags(t *testing.T, tileEtags bool) (mockBucket, *Server) {
 	bucket := mockBucket{make(map[string][]byte)}
-	server, err := NewServerWithBucket(bucket, "", log.Default(), 10, "", "tiles.example.com")
+	server, err := NewServerWithBucket(bucket, "", log.Default(), 10, "", "tiles.example.com", tileEtags)
 	assert.Nil(t, err)
 	server.Start()
 	return bucket, server
@@ -369,4 +373,85 @@ func TestInvalidateCacheOnMetadataRequest(t *testing.T) {
 	assert.JSONEq(t, `{
 		"meta": "data2"
 	}`, string(data))
+}
+
+func TestEtagResponsesFromArchive(t *testing.T) {
+	mockBucket, server := newServerWithTileEtags(t, false)
+	header := HeaderV3{
+		TileType: Mvt,
+	}
+	mockBucket.items["archive.pmtiles"] = fakeArchive(t, header, map[string]interface{}{}, map[Zxy][]byte{
+		{0, 0, 0}: {0, 1, 2, 3},
+		{4, 1, 2}: {1, 2, 3},
+	}, false)
+
+	statusCode, headers000v1, _ := server.Get(context.Background(), "/archive/0/0/0.mvt")
+	assert.Equal(t, 200, statusCode)
+	statusCode, headers412v1, _ := server.Get(context.Background(), "/archive/4/1/2.mvt")
+	assert.Equal(t, 200, statusCode)
+	statusCode, headers311v1, _ := server.Get(context.Background(), "/archive/3/1/1.mvt")
+	assert.Equal(t, 204, statusCode)
+
+	mockBucket.items["archive.pmtiles"] = fakeArchive(t, header, map[string]interface{}{}, map[Zxy][]byte{
+		{0, 0, 0}: {0, 1, 2, 3},
+		{4, 1, 2}: {1, 2, 3, 4}, // different
+	}, false)
+
+	statusCode, headers000v2, _ := server.Get(context.Background(), "/archive/0/0/0.mvt")
+	assert.Equal(t, 200, statusCode)
+	statusCode, headers412v2, _ := server.Get(context.Background(), "/archive/4/1/2.mvt")
+	assert.Equal(t, 200, statusCode)
+	statusCode, headers311v2, _ := server.Get(context.Background(), "/archive/3/1/1.mvt")
+	assert.Equal(t, 204, statusCode)
+
+	assert.Equal(t, headers000v1["Etag"], headers412v1["Etag"])
+	assert.NotEqual(t, headers000v1["Etag"], headers000v2["Etag"])
+	assert.Equal(t, headers000v2["Etag"], headers412v2["Etag"])
+
+	assert.Equal(t, "", headers311v1["Etag"])
+	assert.Equal(t, "", headers311v2["Etag"])
+}
+
+func TestEtagResponsesFromTile(t *testing.T) {
+	mockBucket, server := newServerWithTileEtags(t, true)
+	header := HeaderV3{
+		TileType: Mvt,
+	}
+	mockBucket.items["archive.pmtiles"] = fakeArchive(t, header, map[string]interface{}{}, map[Zxy][]byte{
+		{0, 0, 0}: {0, 1, 2, 3},
+		{4, 1, 2}: {1, 2, 3},
+	}, false)
+
+	statusCode, headers000v1, _ := server.Get(context.Background(), "/archive/0/0/0.mvt")
+	assert.Equal(t, 200, statusCode)
+	statusCode, headers412v1, _ := server.Get(context.Background(), "/archive/4/1/2.mvt")
+	assert.Equal(t, 200, statusCode)
+	statusCode, headers311v1, _ := server.Get(context.Background(), "/archive/3/1/1.mvt")
+	assert.Equal(t, 204, statusCode)
+
+	mockBucket.items["archive.pmtiles"] = fakeArchive(t, header, map[string]interface{}{}, map[Zxy][]byte{
+		{0, 0, 0}: {0, 1, 2, 3},
+		{4, 1, 2}: {1, 2, 3, 4}, // different
+	}, false)
+
+	statusCode, headers000v2, _ := server.Get(context.Background(), "/archive/0/0/0.mvt")
+	assert.Equal(t, 200, statusCode)
+	statusCode, headers412v2, _ := server.Get(context.Background(), "/archive/4/1/2.mvt")
+	assert.Equal(t, 200, statusCode)
+	statusCode, headers311v2, _ := server.Get(context.Background(), "/archive/3/1/1.mvt")
+	assert.Equal(t, 204, statusCode)
+
+	// 204's have no etag
+	assert.Equal(t, "", headers311v1["Etag"])
+	assert.Equal(t, "", headers311v2["Etag"])
+
+	// 000 and 311 didn't change
+	assert.Equal(t, headers000v1["Etag"], headers000v2["Etag"])
+
+	// 412 did change
+	assert.NotEqual(t, headers412v1["Etag"], headers412v2["Etag"])
+
+	// all are different
+	assert.NotEqual(t, headers000v1["Etag"], headers311v1["Etag"])
+	assert.NotEqual(t, headers000v1["Etag"], headers412v1["Etag"])
 }


### PR DESCRIPTION
Set etag on tile, metadata, and tilejson responses. By default it uses the etag from the archive but you can opt into computing an etag per-resource with `--tile-etag` flag. The default archive etag behavior minimizes runtime overhead and is guaranteed to return a new etag when tile contents changes, but also ends up changing the etag (and purging intermediate caches) when the archive changes but an individual tile is the same between old and new archive.

This also implements `If-Match` and `If-None-Match` header handling by using go's built-in [`http.ServeContent`](https://pkg.go.dev/net/http#ServeContent) utility. As a side effect this also means that `pmtiles serve` now supports range requests within individual tiles.