### PR TITLE
Add more prometheus metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -136,6 +136,7 @@ func main() {
 			logger.Fatalf("Failed to create new server, %v", err)
 		}
 
+		pmtiles.SetBuildInfo(version, commit, date)
 		server.Start()
 
 		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/pmtiles/server.go
+++ b/pmtiles/server.go
@@ -25,7 +25,6 @@ type cacheKey struct {
 type request struct {
 	key       cacheKey
 	value     chan cachedValue
-	miss      chan int
 	purgeEtag string
 }
 
@@ -126,15 +125,12 @@ func (server *Server) Start() {
 				key := req.key
 				if val, ok := cache[key]; ok {
 					evictList.MoveToFront(val)
-					req.miss <- 0
 					req.value <- val.Value.(*response).value
 					server.metrics.cacheRequest(key.name, "hit")
 				} else if _, ok := inflight[key]; ok {
-					req.miss <- 0
 					inflight[key] = append(inflight[key], req)
 					server.metrics.cacheRequest(key.name, "hit") // treat inflight as a hit since it doesn't make a new server request
 				} else {
-					req.miss <- 1
 					inflight[key] = []request{req}
 					server.metrics.cacheRequest(key.name, "miss")
 					go func() {
@@ -244,7 +240,7 @@ func (server *Server) getHeaderMetadata(ctx context.Context, name string) (bool,
 }
 
 func (server *Server) getHeaderMetadataAttempt(ctx context.Context, name, purgeEtag string) (bool, HeaderV3, []byte, string, error) {
-	rootReq := request{key: cacheKey{name: name, offset: 0, length: 0}, value: make(chan cachedValue, 1), miss: make(chan int, 1), purgeEtag: purgeEtag}
+	rootReq := request{key: cacheKey{name: name, offset: 0, length: 0}, value: make(chan cachedValue, 1), purgeEtag: purgeEtag}
 	server.reqs <- rootReq
 	rootValue := <-rootReq.value
 	header := rootValue.header
@@ -325,52 +321,51 @@ func (server *Server) getMetadata(ctx context.Context, httpHeaders map[string]st
 	httpHeaders["Etag"] = generateEtag(metadataBytes)
 	return 200, httpHeaders, metadataBytes
 }
-func (server *Server) getTile(ctx context.Context, httpHeaders map[string]string, name string, z uint8, x uint32, y uint32, ext string) (int, map[string]string, []byte, int) {
-	status, headers, data, dirMisses, purgeEtag := server.getTileAttempt(ctx, httpHeaders, name, z, x, y, ext, "")
+func (server *Server) getTile(ctx context.Context, httpHeaders map[string]string, name string, z uint8, x uint32, y uint32, ext string) (int, map[string]string, []byte) {
+	status, headers, data, purgeEtag := server.getTileAttempt(ctx, httpHeaders, name, z, x, y, ext, "")
 	if len(purgeEtag) > 0 {
 		// file has new etag, retry once force-purging the etag that is no longer value
-		status, headers, data, dirMisses, _ = server.getTileAttempt(ctx, httpHeaders, name, z, x, y, ext, purgeEtag)
+		status, headers, data, _ = server.getTileAttempt(ctx, httpHeaders, name, z, x, y, ext, purgeEtag)
 	}
-	return status, headers, data, dirMisses
+	return status, headers, data
 }
 
-func (server *Server) getTileAttempt(ctx context.Context, httpHeaders map[string]string, name string, z uint8, x uint32, y uint32, ext string, purgeEtag string) (int, map[string]string, []byte, int, string) {
-	rootReq := request{key: cacheKey{name: name, offset: 0, length: 0}, value: make(chan cachedValue, 1), miss: make(chan int, 1), purgeEtag: purgeEtag}
+func (server *Server) getTileAttempt(ctx context.Context, httpHeaders map[string]string, name string, z uint8, x uint32, y uint32, ext string, purgeEtag string) (int, map[string]string, []byte, string) {
+	rootReq := request{key: cacheKey{name: name, offset: 0, length: 0}, value: make(chan cachedValue, 1), purgeEtag: purgeEtag}
 	server.reqs <- rootReq
 
 	// https://golang.org/doc/faq#atomic_maps
 	rootValue := <-rootReq.value
-	dirMisses := <-rootReq.miss
 	header := rootValue.header
 
 	if !rootValue.ok {
-		return 404, httpHeaders, []byte("Archive not found"), dirMisses, ""
+		return 404, httpHeaders, []byte("Archive not found"), ""
 	}
 
 	if z < header.MinZoom || z > header.MaxZoom {
-		return 404, httpHeaders, []byte("Tile not found"), dirMisses, ""
+		return 404, httpHeaders, []byte("Tile not found"), ""
 	}
 
 	switch header.TileType {
 	case Mvt:
 		if ext != "mvt" {
-			return 400, httpHeaders, []byte("path mismatch: archive is type MVT (.mvt)"), dirMisses, ""
+			return 400, httpHeaders, []byte("path mismatch: archive is type MVT (.mvt)"), ""
 		}
 	case Png:
 		if ext != "png" {
-			return 400, httpHeaders, []byte("path mismatch: archive is type PNG (.png)"), dirMisses, ""
+			return 400, httpHeaders, []byte("path mismatch: archive is type PNG (.png)"), ""
 		}
 	case Jpeg:
 		if ext != "jpg" {
-			return 400, httpHeaders, []byte("path mismatch: archive is type JPEG (.jpg)"), dirMisses, ""
+			return 400, httpHeaders, []byte("path mismatch: archive is type JPEG (.jpg)"), ""
 		}
 	case Webp:
 		if ext != "webp" {
-			return 400, httpHeaders, []byte("path mismatch: archive is type WebP (.webp)"), dirMisses, ""
+			return 400, httpHeaders, []byte("path mismatch: archive is type WebP (.webp)"), ""
 		}
 	case Avif:
 		if ext != "avif" {
-			return 400, httpHeaders, []byte("path mismatch: archive is type AVIF (.avif)"), dirMisses, ""
+			return 400, httpHeaders, []byte("path mismatch: archive is type AVIF (.avif)"), ""
 		}
 	}
 
@@ -378,12 +373,11 @@ func (server *Server) getTileAttempt(ctx context.Context, httpHeaders map[string
 	dirOffset, dirLen := header.RootOffset, header.RootLength
 
 	for depth := 0; depth <= 3; depth++ {
-		dirReq := request{key: cacheKey{name: name, offset: dirOffset, length: dirLen, etag: rootValue.etag}, value: make(chan cachedValue, 1), miss: make(chan int, 1)}
+		dirReq := request{key: cacheKey{name: name, offset: dirOffset, length: dirLen, etag: rootValue.etag}, value: make(chan cachedValue, 1)}
 		server.reqs <- dirReq
 		dirValue := <-dirReq.value
-		dirMisses = dirMisses + <-dirReq.miss
 		if dirValue.badEtag {
-			return 500, httpHeaders, []byte("I/O Error"), dirMisses, rootValue.etag
+			return 500, httpHeaders, []byte("I/O Error"), rootValue.etag
 		}
 		directory := dirValue.directory
 		entry, ok := findTile(directory, tileID)
@@ -398,24 +392,24 @@ func (server *Server) getTileAttempt(ctx context.Context, httpHeaders map[string
 			r, _, statusCode, err := server.bucket.NewRangeReaderEtag(ctx, name+".pmtiles", int64(header.TileDataOffset+entry.Offset), int64(entry.Length), rootValue.etag)
 			status = strconv.Itoa(statusCode)
 			if isRefreshRequredError(err) {
-				return 500, httpHeaders, []byte("I/O Error"), dirMisses, rootValue.etag
+				return 500, httpHeaders, []byte("I/O Error"), rootValue.etag
 			}
 			// possible we have the header/directory cached but the archive has disappeared
 			if err != nil {
 				if isCanceled(ctx) {
-					return 499, httpHeaders, []byte("Canceled"), dirMisses, ""
+					return 499, httpHeaders, []byte("Canceled"), ""
 				}
 				server.logger.Printf("failed to fetch tile %s %d-%d %v", name, entry.Offset, entry.Length, err)
-				return 404, httpHeaders, []byte("Tile not found"), dirMisses, ""
+				return 404, httpHeaders, []byte("Tile not found"), ""
 			}
 			defer r.Close()
 			b, err := io.ReadAll(r)
 			if err != nil {
 				status = "error"
 				if isCanceled(ctx) {
-					return 499, httpHeaders, []byte("Canceled"), dirMisses, ""
+					return 499, httpHeaders, []byte("Canceled"), ""
 				}
-				return canceledOrStatusCode(ctx, 500), httpHeaders, []byte("I/O error"), dirMisses, ""
+				return canceledOrStatusCode(ctx, 500), httpHeaders, []byte("I/O error"), ""
 			}
 
 			httpHeaders["Etag"] = generateEtag(b)
@@ -425,12 +419,12 @@ func (server *Server) getTileAttempt(ctx context.Context, httpHeaders map[string
 			if headerVal, ok := headerContentEncoding(header.TileCompression); ok {
 				httpHeaders["Content-Encoding"] = headerVal
 			}
-			return 200, httpHeaders, b, dirMisses, ""
+			return 200, httpHeaders, b, ""
 		}
 		dirOffset = header.LeafDirectoryOffset + entry.Offset
 		dirLen = uint64(entry.Length)
 	}
-	return 204, httpHeaders, nil, dirMisses, ""
+	return 204, httpHeaders, nil, ""
 }
 
 func isRefreshRequredError(err error) bool {
@@ -488,7 +482,7 @@ func parseMetadataPath(path string) (bool, string) {
 	return false, ""
 }
 
-func (server *Server) get(ctx context.Context, path string) (archive, handler string, status int, headers map[string]string, data []byte, dirMisses int) {
+func (server *Server) get(ctx context.Context, path string) (archive, handler string, status int, headers map[string]string, data []byte) {
 	handler = ""
 	archive = ""
 	headers = make(map[string]string)
@@ -498,7 +492,7 @@ func (server *Server) get(ctx context.Context, path string) (archive, handler st
 
 	if ok, key, z, x, y, ext := parseTilePath(path); ok {
 		archive, handler = key, "tile"
-		status, headers, data, dirMisses = server.getTile(ctx, headers, key, z, x, y, ext)
+		status, headers, data = server.getTile(ctx, headers, key, z, x, y, ext)
 	} else if ok, key := parseTilejsonPath(path); ok {
 		archive, handler = key, "tilejson"
 		status, headers, data = server.getTileJSON(ctx, headers, key)
@@ -518,8 +512,8 @@ func (server *Server) get(ctx context.Context, path string) (archive, handler st
 // Return status code, HTTP headers, and body.
 func (server *Server) Get(ctx context.Context, path string) (int, map[string]string, []byte) {
 	tracker := server.metrics.startRequest()
-	archive, handler, status, headers, data, dirMisses := server.get(ctx, path)
-	tracker.finish(ctx, archive, handler, status, len(data), true, dirMisses)
+	archive, handler, status, headers, data := server.get(ctx, path)
+	tracker.finish(ctx, archive, handler, status, len(data), true)
 	return status, headers, data
 }
 
@@ -541,14 +535,14 @@ func (server *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) int {
 			w.Header().Set("Access-Control-Allow-Origin", server.cors)
 		}
 		w.WriteHeader(204)
-		tracker.finish(r.Context(), "", r.Method, 204, 0, false, 0)
+		tracker.finish(r.Context(), "", r.Method, 204, 0, false)
 		return 204
 	} else if r.Method != http.MethodGet && r.Method != http.MethodHead {
 		w.WriteHeader(405)
-		tracker.finish(r.Context(), "", r.Method, 405, 0, false, 0)
+		tracker.finish(r.Context(), "", r.Method, 405, 0, false)
 		return 405
 	}
-	archive, handler, statusCode, headers, body, dirMisses := server.get(r.Context(), r.URL.Path)
+	archive, handler, statusCode, headers, body := server.get(r.Context(), r.URL.Path)
 	for k, v := range headers {
 		w.Header().Set(k, v)
 	}
@@ -566,7 +560,7 @@ func (server *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) int {
 		w.WriteHeader(statusCode)
 		w.Write(body)
 	}
-	tracker.finish(r.Context(), archive, handler, statusCode, len(body), true, dirMisses)
+	tracker.finish(r.Context(), archive, handler, statusCode, len(body), true)
 
 	return statusCode
 }

--- a/pmtiles/server.go
+++ b/pmtiles/server.go
@@ -180,6 +180,7 @@ func (server *Server) Start() {
 								server.logger.Printf("parsing header failed: %v", err)
 								return
 							}
+							tracker.finish(status) // track time to deserialize a header separately
 
 							// populate the root first before header
 							rootEntries := deserializeEntries(bytes.NewBuffer(b[header.RootOffset : header.RootOffset+header.RootLength]))

--- a/pmtiles/server.go
+++ b/pmtiles/server.go
@@ -129,7 +129,7 @@ func (server *Server) Start() {
 					server.metrics.cacheRequest(key.name, "hit")
 				} else if _, ok := inflight[key]; ok {
 					inflight[key] = append(inflight[key], req)
-					server.metrics.cacheRequest(key.name, "inflight")
+					server.metrics.cacheRequest(key.name, "hit") // treat inflight as a hit since it doesn't make a new server request
 				} else {
 					inflight[key] = []request{req}
 					server.metrics.cacheRequest(key.name, "miss")

--- a/pmtiles/server.go
+++ b/pmtiles/server.go
@@ -409,7 +409,7 @@ func (server *Server) getTileAttempt(ctx context.Context, httpHeaders map[string
 				if isCanceled(ctx) {
 					return 499, httpHeaders, []byte("Canceled"), ""
 				}
-				return canceledOrStatusCode(ctx, 500), httpHeaders, []byte("I/O error"), ""
+				return 500, httpHeaders, []byte("I/O error"), ""
 			}
 
 			httpHeaders["Etag"] = generateEtag(b)
@@ -430,20 +430,6 @@ func (server *Server) getTileAttempt(ctx context.Context, httpHeaders map[string
 func isRefreshRequredError(err error) bool {
 	_, ok := err.(*RefreshRequiredError)
 	return ok
-}
-
-func canceledOrError(ctx context.Context) string {
-	if isCanceled(ctx) {
-		return "canceled"
-	}
-	return "error"
-}
-
-func canceledOrStatusCode(ctx context.Context, code int) int {
-	if isCanceled(ctx) {
-		return 499
-	}
-	return code
 }
 
 func isCanceled(ctx context.Context) bool {

--- a/pmtiles/server.go
+++ b/pmtiles/server.go
@@ -513,7 +513,7 @@ func (server *Server) get(ctx context.Context, path string) (archive, handler st
 func (server *Server) Get(ctx context.Context, path string) (int, map[string]string, []byte) {
 	tracker := server.metrics.startRequest()
 	archive, handler, status, headers, data := server.get(ctx, path)
-	tracker.finish(archive, handler, status, len(data), true)
+	tracker.finish(ctx, archive, handler, status, len(data), true)
 	return status, headers, data
 }
 
@@ -535,11 +535,11 @@ func (server *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) int {
 			w.Header().Set("Access-Control-Allow-Origin", server.cors)
 		}
 		w.WriteHeader(204)
-		tracker.finish("", r.Method, 204, 0, false)
+		tracker.finish(r.Context(), "", r.Method, 204, 0, false)
 		return 204
 	} else if r.Method != http.MethodGet && r.Method != http.MethodHead {
 		w.WriteHeader(405)
-		tracker.finish("", r.Method, 405, 0, false)
+		tracker.finish(r.Context(), "", r.Method, 405, 0, false)
 		return 405
 	}
 	archive, handler, statusCode, headers, body := server.get(r.Context(), r.URL.Path)
@@ -560,7 +560,7 @@ func (server *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) int {
 		w.WriteHeader(statusCode)
 		w.Write(body)
 	}
-	tracker.finish(archive, handler, statusCode, len(body), true)
+	tracker.finish(r.Context(), archive, handler, statusCode, len(body), true)
 
 	return statusCode
 }

--- a/pmtiles/server_metrics.go
+++ b/pmtiles/server_metrics.go
@@ -74,13 +74,13 @@ func (r *requestTracker) finish(ctx context.Context, archive, handler string, st
 	if !r.finished {
 		r.finished = true
 		// exclude archive path from "not found" metrics to limit cardinality on requests for nonexistant archives
+		statusString := strconv.Itoa(status)
 		if status == 404 {
 			archive = ""
-		}
-		statusString := strconv.Itoa(status)
-		if isCanceled(ctx) {
+		} else if isCanceled(ctx) {
 			statusString = "canceled"
 		}
+
 		labels := []string{archive, handler, statusString}
 		r.metrics.requests.WithLabelValues(labels...).Inc()
 		if logDetails {
@@ -109,8 +109,7 @@ func (r *bucketRequestTracker) finish(ctx context.Context, status string) {
 		// exclude archive path from "not found" metrics to limit cardinality on requests for nonexistant archives
 		if status == "404" || status == "403" {
 			r.archive = ""
-		}
-		if isCanceled(ctx) {
+		} else if isCanceled(ctx) {
 			status = "canceled"
 		}
 		r.metrics.bucketRequests.WithLabelValues(r.archive, r.kind, status).Inc()

--- a/pmtiles/server_metrics.go
+++ b/pmtiles/server_metrics.go
@@ -133,8 +133,8 @@ func (m *metrics) updateCacheStats(sizeBytes, entries int) {
 	m.dirCacheSizeBytes.Set(float64(sizeBytes))
 }
 
-func (m *metrics) cacheRequest(archive, status string) {
-	m.dirCacheRequests.WithLabelValues(archive, status).Inc()
+func (m *metrics) cacheRequest(archive, kind, status string) {
+	m.dirCacheRequests.WithLabelValues(archive, kind, status).Inc()
 }
 
 func register[K prometheus.Collector](logger *log.Logger, metric K) K {
@@ -198,7 +198,7 @@ func createMetrics(scope string, logger *log.Logger) *metrics {
 			Subsystem: scope,
 			Name:      "dir_cache_requests",
 			Help:      "Requests to the directory cache by archive and status (hit/miss)",
-		}, []string{"archive", "status"})),
+		}, []string{"archive", "kind", "status"})),
 
 		// requests to bucket
 		bucketRequests: register(logger, prometheus.NewCounterVec(prometheus.CounterOpts{

--- a/pmtiles/server_metrics.go
+++ b/pmtiles/server_metrics.go
@@ -1,0 +1,203 @@
+package pmtiles
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var buildInfoMetric = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: "pmtiles",
+	Name:      "buildinfo",
+}, []string{"version", "revision"})
+
+var buildTimeMetric = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: "pmtiles",
+	Name:      "buildtime",
+})
+
+func init() {
+	err := prometheus.Register(buildInfoMetric)
+	if err != nil {
+		fmt.Println("Error registering metric", err)
+	}
+	err = prometheus.Register(buildTimeMetric)
+	if err != nil {
+		fmt.Println("Error registering metric", err)
+	}
+}
+
+// SetBuildInfo initializes static metrics with pmtiles version, git hash, and build time
+func SetBuildInfo(version, commit, date string) {
+	buildInfoMetric.WithLabelValues(version, commit).Set(1)
+	time, err := time.Parse(time.RFC3339, date)
+	if err == nil {
+		buildTimeMetric.Set(float64(time.Unix()))
+	} else {
+		buildTimeMetric.Set(0)
+	}
+}
+
+type metrics struct {
+	// overall requests: # requests, request duration, response size by archive/status code
+	requests        *prometheus.CounterVec
+	responseSize    *prometheus.HistogramVec
+	requestDuration *prometheus.HistogramVec
+	// dir cache: # requests, hits, cache entries, cache bytes, cache bytes limit
+	dirCacheEntries    prometheus.Gauge
+	dirCacheSizeBytes  prometheus.Gauge
+	dirCacheLimitBytes prometheus.Gauge
+	dirCacheRequests   *prometheus.CounterVec
+	// requests to bucket: # total, response duration by archive/status code
+	bucketRequests        *prometheus.CounterVec
+	bucketRequestDuration *prometheus.HistogramVec
+	// misc
+	reloads *prometheus.CounterVec
+}
+
+// utility to time an overall tile request
+type requestTracker struct {
+	start   time.Time
+	metrics *metrics
+}
+
+func (m *metrics) startRequest() *requestTracker {
+	return &requestTracker{start: time.Now(), metrics: m}
+}
+
+func (r *requestTracker) finish(archive, handler string, status, responseSize int, logDetails bool) {
+	labels := []string{archive, handler, strconv.Itoa(status)}
+	r.metrics.requests.WithLabelValues(labels...).Inc()
+	if logDetails {
+		r.metrics.responseSize.WithLabelValues(labels...).Observe(float64(responseSize))
+		r.metrics.requestDuration.WithLabelValues(labels...).Observe(time.Since(r.start).Seconds())
+	}
+}
+
+// utility to time an individual request to the underlying bucket
+type bucketRequestTracker struct {
+	start   time.Time
+	metrics *metrics
+	archive string
+}
+
+func (m *metrics) startBucketRequest(archive string) *bucketRequestTracker {
+	return &bucketRequestTracker{start: time.Now(), metrics: m, archive: archive}
+}
+
+func (r *bucketRequestTracker) finish(status string) {
+	labels := []string{r.archive, status}
+	r.metrics.bucketRequests.WithLabelValues(labels...).Inc()
+	r.metrics.bucketRequestDuration.WithLabelValues(labels...).Observe(time.Since(r.start).Seconds())
+}
+
+// misc helpers
+
+func (m *metrics) reloadFile(name string) {
+	m.reloads.WithLabelValues(name).Inc()
+}
+
+func (m *metrics) initCacheStats(limitBytes int) {
+	m.dirCacheLimitBytes.Set(float64(limitBytes))
+	m.updateCacheStats(0, 0)
+}
+
+func (m *metrics) updateCacheStats(sizeBytes, entries int) {
+	m.dirCacheEntries.Set(float64(entries))
+	m.dirCacheSizeBytes.Set(float64(sizeBytes))
+}
+
+func (m *metrics) cacheRequest(archive, status string) {
+	m.dirCacheRequests.WithLabelValues(archive, status).Inc()
+}
+
+func register[K prometheus.Collector](logger *log.Logger, metric K) K {
+	if err := prometheus.Register(metric); err != nil {
+		logger.Println(err)
+	}
+	return metric
+}
+
+func createMetrics(scope string, logger *log.Logger) *metrics {
+	namespace := "pmtiles"
+	durationBuckets := prometheus.DefBuckets
+	kib := 1024.0
+	mib := kib * kib
+	sizeBuckets := []float64{1.0 * kib, 5.0 * kib, 10.0 * kib, 50.0 * kib, 100 * kib, 200 * kib, 500 * kib, 1.0 * mib, 2.5 * mib, 5.0 * mib}
+
+	return &metrics{
+		// overall requests
+		requests: register(logger, prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: scope,
+			Name:      "requests_total",
+			Help:      "Overall number of requests to the service",
+		}, []string{"archive", "handler", "status"})),
+		responseSize: register(logger, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: scope,
+			Name:      "response_size_bytes",
+			Help:      "Overall response size in bytes",
+			Buckets:   sizeBuckets,
+		}, []string{"archive", "handler", "status"})),
+		requestDuration: register(logger, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: scope,
+			Name:      "request_duration_seconds",
+			Help:      "Overall request duration in seconds",
+			Buckets:   durationBuckets,
+		}, []string{"archive", "handler", "status"})),
+
+		// dir cache
+		dirCacheEntries: register(logger, prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: scope,
+			Name:      "dir_cache_entries",
+			Help:      "Number of directories in the cache",
+		})),
+		dirCacheSizeBytes: register(logger, prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: scope,
+			Name:      "dir_cache_size_bytes",
+			Help:      "Current directory cache usage in bytes",
+		})),
+		dirCacheLimitBytes: register(logger, prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: scope,
+			Name:      "dir_cache_limit_bytes",
+			Help:      "Maximum directory cache size limit in bytes",
+		})),
+		dirCacheRequests: register(logger, prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: scope,
+			Name:      "dir_cache_requests",
+			Help:      "Requests to the directory cache by archive and status (hit/inflight/miss)",
+		}, []string{"archive", "status"})),
+
+		// requests to bucket
+		bucketRequests: register(logger, prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: scope,
+			Name:      "bucket_requests_total",
+			Help:      "Requests to the underlying bucket",
+		}, []string{"archive", "status"})),
+		bucketRequestDuration: register(logger, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: scope,
+			Name:      "bucket_request_duration_seconds",
+			Help:      "Request duration in seconds for individual requests to the underlying bucket",
+			Buckets:   durationBuckets,
+		}, []string{"archive", "status"})),
+
+		// misc
+		reloads: register(logger, prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: scope,
+			Name:      "bucket_reloads",
+			Help:      "Number of times an archive was reloaded due to the etag changing",
+		}, []string{"archive"})),
+	}
+}

--- a/pmtiles/server_metrics.go
+++ b/pmtiles/server_metrics.go
@@ -70,7 +70,7 @@ func (m *metrics) startRequest() *requestTracker {
 	return &requestTracker{start: time.Now(), metrics: m}
 }
 
-func (r *requestTracker) finish(ctx context.Context, archive, handler string, status, responseSize int, logDetails bool, dirMisses int) {
+func (r *requestTracker) finish(ctx context.Context, archive, handler string, status, responseSize int, logDetails bool) {
 	if !r.finished {
 		r.finished = true
 		// exclude archive path from "not found" metrics to limit cardinality on requests for nonexistant archives
@@ -81,7 +81,7 @@ func (r *requestTracker) finish(ctx context.Context, archive, handler string, st
 		if isCanceled(ctx) {
 			statusString = "canceled"
 		}
-		labels := []string{archive, handler, statusString, strconv.Itoa(dirMisses)}
+		labels := []string{archive, handler, statusString}
 		r.metrics.requests.WithLabelValues(labels...).Inc()
 		if logDetails {
 			r.metrics.responseSize.WithLabelValues(labels...).Observe(float64(responseSize))
@@ -159,21 +159,21 @@ func createMetrics(scope string, logger *log.Logger) *metrics {
 			Subsystem: scope,
 			Name:      "requests_total",
 			Help:      "Overall number of requests to the service",
-		}, []string{"archive", "handler", "status", "dir_misses"})),
+		}, []string{"archive", "handler", "status"})),
 		responseSize: register(logger, prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: scope,
 			Name:      "response_size_bytes",
 			Help:      "Overall response size in bytes",
 			Buckets:   sizeBuckets,
-		}, []string{"archive", "handler", "status", "dir_misses"})),
+		}, []string{"archive", "handler", "status"})),
 		requestDuration: register(logger, prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: scope,
 			Name:      "request_duration_seconds",
 			Help:      "Overall request duration in seconds",
 			Buckets:   durationBuckets,
-		}, []string{"archive", "handler", "status", "dir_misses"})),
+		}, []string{"archive", "handler", "status"})),
 
 		// dir cache
 		dirCacheEntries: register(logger, prometheus.NewGauge(prometheus.GaugeOpts{

--- a/pmtiles/server_metrics.go
+++ b/pmtiles/server_metrics.go
@@ -70,7 +70,7 @@ func (m *metrics) startRequest() *requestTracker {
 	return &requestTracker{start: time.Now(), metrics: m}
 }
 
-func (r *requestTracker) finish(ctx context.Context, archive, handler string, status, responseSize int, logDetails bool) {
+func (r *requestTracker) finish(ctx context.Context, archive, handler string, status, responseSize int, logDetails bool, dirMisses int) {
 	if !r.finished {
 		r.finished = true
 		// exclude archive path from "not found" metrics to limit cardinality on requests for nonexistant archives
@@ -81,7 +81,7 @@ func (r *requestTracker) finish(ctx context.Context, archive, handler string, st
 		if isCanceled(ctx) {
 			statusString = "canceled"
 		}
-		labels := []string{archive, handler, statusString}
+		labels := []string{archive, handler, statusString, strconv.Itoa(dirMisses)}
 		r.metrics.requests.WithLabelValues(labels...).Inc()
 		if logDetails {
 			r.metrics.responseSize.WithLabelValues(labels...).Observe(float64(responseSize))
@@ -159,21 +159,21 @@ func createMetrics(scope string, logger *log.Logger) *metrics {
 			Subsystem: scope,
 			Name:      "requests_total",
 			Help:      "Overall number of requests to the service",
-		}, []string{"archive", "handler", "status"})),
+		}, []string{"archive", "handler", "status", "dir_misses"})),
 		responseSize: register(logger, prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: scope,
 			Name:      "response_size_bytes",
 			Help:      "Overall response size in bytes",
 			Buckets:   sizeBuckets,
-		}, []string{"archive", "handler", "status"})),
+		}, []string{"archive", "handler", "status", "dir_misses"})),
 		requestDuration: register(logger, prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: scope,
 			Name:      "request_duration_seconds",
 			Help:      "Overall request duration in seconds",
 			Buckets:   durationBuckets,
-		}, []string{"archive", "handler", "status"})),
+		}, []string{"archive", "handler", "status", "dir_misses"})),
 
 		// dir cache
 		dirCacheEntries: register(logger, prometheus.NewGauge(prometheus.GaugeOpts{

--- a/pmtiles/server_metrics.go
+++ b/pmtiles/server_metrics.go
@@ -126,7 +126,7 @@ func createMetrics(scope string, logger *log.Logger) *metrics {
 	durationBuckets := prometheus.DefBuckets
 	kib := 1024.0
 	mib := kib * kib
-	sizeBuckets := []float64{1.0 * kib, 5.0 * kib, 10.0 * kib, 50.0 * kib, 100 * kib, 200 * kib, 500 * kib, 1.0 * mib, 2.5 * mib, 5.0 * mib}
+	sizeBuckets := []float64{1.0 * kib, 5.0 * kib, 10.0 * kib, 25.0 * kib, 50.0 * kib, 100 * kib, 250 * kib, 500 * kib, 1.0 * mib}
 
 	return &metrics{
 		// overall requests
@@ -174,7 +174,7 @@ func createMetrics(scope string, logger *log.Logger) *metrics {
 			Namespace: namespace,
 			Subsystem: scope,
 			Name:      "dir_cache_requests",
-			Help:      "Requests to the directory cache by archive and status (hit/inflight/miss)",
+			Help:      "Requests to the directory cache by archive and status (hit/miss)",
 		}, []string{"archive", "status"})),
 
 		// requests to bucket

--- a/pmtiles/server_test.go
+++ b/pmtiles/server_test.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -108,6 +109,7 @@ func fakeArchive(t *testing.T, header HeaderV3, metadata map[string]interface{},
 }
 
 func newServer(t *testing.T) (mockBucket, *Server) {
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
 	bucket := mockBucket{make(map[string][]byte)}
 	server, err := NewServerWithBucket(bucket, "", log.Default(), 10, "", "tiles.example.com")
 	assert.Nil(t, err)


### PR DESCRIPTION
Add more prometheus metrics to pmtiles server:

- overall HTTP request duration, response size, and count by status/archive/handler
- underlying bucket request duration and count by status/archive
- directory cache size/limit, requests by hit/miss/inflight status

Also fixed a few things I found testing out the corner cases:

- translate any client cancellation exceptions to a 499 http response code, otherwise they are 500 and look like server failures in the stats
- return a 204 for OPTIONS requests since if there's a body the client will cancel reading it
- return a 405 for any other request methods besides GET/HEAD/OPTIONS - it doesn't seem like those should be supported?

The impact on performance seems to be negligible, tilesiege with 1.25m requests was around 37k qps before/after this change.

<details>
<summary>
Example /metrics response after a bunch of requests to "planet" archive that exists and "plaet" archive that does not
</summary>

```
# HELP pmtiles_bucket_request_duration_seconds Request duration in seconds for individual requests to the underlying bucket
# TYPE pmtiles_bucket_request_duration_seconds histogram
pmtiles_bucket_request_duration_seconds_bucket{archive="",status="404",le="0.005"} 40
pmtiles_bucket_request_duration_seconds_bucket{archive="",status="404",le="0.01"} 51
pmtiles_bucket_request_duration_seconds_bucket{archive="",status="404",le="0.025"} 70
pmtiles_bucket_request_duration_seconds_bucket{archive="",status="404",le="0.05"} 116
pmtiles_bucket_request_duration_seconds_bucket{archive="",status="404",le="0.1"} 126
pmtiles_bucket_request_duration_seconds_bucket{archive="",status="404",le="0.25"} 130
pmtiles_bucket_request_duration_seconds_bucket{archive="",status="404",le="0.5"} 130
pmtiles_bucket_request_duration_seconds_bucket{archive="",status="404",le="1"} 130
pmtiles_bucket_request_duration_seconds_bucket{archive="",status="404",le="2.5"} 130
pmtiles_bucket_request_duration_seconds_bucket{archive="",status="404",le="5"} 130
pmtiles_bucket_request_duration_seconds_bucket{archive="",status="404",le="10"} 130
pmtiles_bucket_request_duration_seconds_bucket{archive="",status="404",le="+Inf"} 130
pmtiles_bucket_request_duration_seconds_sum{archive="",status="404"} 3.3402572059999986
pmtiles_bucket_request_duration_seconds_count{archive="",status="404"} 130
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="206",le="0.005"} 0
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="206",le="0.01"} 0
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="206",le="0.025"} 2
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="206",le="0.05"} 32
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="206",le="0.1"} 94
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="206",le="0.25"} 118
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="206",le="0.5"} 118
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="206",le="1"} 118
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="206",le="2.5"} 118
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="206",le="5"} 118
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="206",le="10"} 118
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="206",le="+Inf"} 118
pmtiles_bucket_request_duration_seconds_sum{archive="planet",status="206"} 8.975607534
pmtiles_bucket_request_duration_seconds_count{archive="planet",status="206"} 118
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="canceled",le="0.005"} 0
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="canceled",le="0.01"} 0
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="canceled",le="0.025"} 0
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="canceled",le="0.05"} 5
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="canceled",le="0.1"} 6
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="canceled",le="0.25"} 8
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="canceled",le="0.5"} 8
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="canceled",le="1"} 8
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="canceled",le="2.5"} 8
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="canceled",le="5"} 8
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="canceled",le="10"} 8
pmtiles_bucket_request_duration_seconds_bucket{archive="planet",status="canceled",le="+Inf"} 8
pmtiles_bucket_request_duration_seconds_sum{archive="planet",status="canceled"} 0.512169418
pmtiles_bucket_request_duration_seconds_count{archive="planet",status="canceled"} 8
# HELP pmtiles_bucket_requests_total Requests to the underlying bucket
# TYPE pmtiles_bucket_requests_total counter
pmtiles_bucket_requests_total{archive="",kind="root",status="404"} 10
pmtiles_bucket_requests_total{archive="",kind="tile",status="404"} 120
pmtiles_bucket_requests_total{archive="planet",kind="leaf",status="206"} 10
pmtiles_bucket_requests_total{archive="planet",kind="root",status="206"} 1
pmtiles_bucket_requests_total{archive="planet",kind="tile",status="206"} 107
pmtiles_bucket_requests_total{archive="planet",kind="tile",status="canceled"} 8
# HELP pmtiles_buildinfo 
# TYPE pmtiles_buildinfo gauge
pmtiles_buildinfo{revision="none",version="dev"} 1
# HELP pmtiles_buildtime 
# TYPE pmtiles_buildtime gauge
pmtiles_buildtime 0
# HELP pmtiles_dir_cache_entries Number of directories in the cache
# TYPE pmtiles_dir_cache_entries gauge
pmtiles_dir_cache_entries 12
# HELP pmtiles_dir_cache_limit_bytes Maximum directory cache size limit in bytes
# TYPE pmtiles_dir_cache_limit_bytes gauge
pmtiles_dir_cache_limit_bytes 6.4e+07
# HELP pmtiles_dir_cache_requests Requests to the directory cache by archive and status (hit/miss)
# TYPE pmtiles_dir_cache_requests counter
pmtiles_dir_cache_requests{archive="planet",status="hit"} 694
pmtiles_dir_cache_requests{archive="planet",status="miss"} 11
pmtiles_dir_cache_requests{archive="plet",status="hit"} 37
pmtiles_dir_cache_requests{archive="plet",status="miss"} 10
# HELP pmtiles_dir_cache_size_bytes Current directory cache usage in bytes
# TYPE pmtiles_dir_cache_size_bytes gauge
pmtiles_dir_cache_size_bytes 3.791191e+06
# HELP pmtiles_request_duration_seconds Overall request duration in seconds
# TYPE pmtiles_request_duration_seconds histogram
pmtiles_request_duration_seconds_bucket{archive="",handler="tile",status="404",le="0.005"} 7
pmtiles_request_duration_seconds_bucket{archive="",handler="tile",status="404",le="0.01"} 8
pmtiles_request_duration_seconds_bucket{archive="",handler="tile",status="404",le="0.025"} 22
pmtiles_request_duration_seconds_bucket{archive="",handler="tile",status="404",le="0.05"} 36
pmtiles_request_duration_seconds_bucket{archive="",handler="tile",status="404",le="0.1"} 39
pmtiles_request_duration_seconds_bucket{archive="",handler="tile",status="404",le="0.25"} 47
pmtiles_request_duration_seconds_bucket{archive="",handler="tile",status="404",le="0.5"} 47
pmtiles_request_duration_seconds_bucket{archive="",handler="tile",status="404",le="1"} 47
pmtiles_request_duration_seconds_bucket{archive="",handler="tile",status="404",le="2.5"} 47
pmtiles_request_duration_seconds_bucket{archive="",handler="tile",status="404",le="5"} 47
pmtiles_request_duration_seconds_bucket{archive="",handler="tile",status="404",le="10"} 47
pmtiles_request_duration_seconds_bucket{archive="",handler="tile",status="404",le="+Inf"} 47
pmtiles_request_duration_seconds_sum{archive="",handler="tile",status="404"} 2.1503623300000005
pmtiles_request_duration_seconds_count{archive="",handler="tile",status="404"} 47
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="200",le="0.005"} 0
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="200",le="0.01"} 0
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="200",le="0.025"} 1
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="200",le="0.05"} 12
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="200",le="0.1"} 41
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="200",le="0.25"} 63
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="200",le="0.5"} 64
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="200",le="1"} 64
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="200",le="2.5"} 64
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="200",le="5"} 64
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="200",le="10"} 64
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="200",le="+Inf"} 64
pmtiles_request_duration_seconds_sum{archive="planet",handler="tile",status="200"} 6.047602334
pmtiles_request_duration_seconds_count{archive="planet",handler="tile",status="200"} 64
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="304",le="0.005"} 0
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="304",le="0.01"} 0
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="304",le="0.025"} 0
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="304",le="0.05"} 3
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="304",le="0.1"} 29
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="304",le="0.25"} 41
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="304",le="0.5"} 43
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="304",le="1"} 43
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="304",le="2.5"} 43
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="304",le="5"} 43
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="304",le="10"} 43
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="304",le="+Inf"} 43
pmtiles_request_duration_seconds_sum{archive="planet",handler="tile",status="304"} 4.370763833
pmtiles_request_duration_seconds_count{archive="planet",handler="tile",status="304"} 43
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="canceled",le="0.005"} 5
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="canceled",le="0.01"} 17
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="canceled",le="0.025"} 39
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="canceled",le="0.05"} 106
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="canceled",le="0.1"} 124
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="canceled",le="0.25"} 128
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="canceled",le="0.5"} 128
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="canceled",le="1"} 128
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="canceled",le="2.5"} 128
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="canceled",le="5"} 128
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="canceled",le="10"} 128
pmtiles_request_duration_seconds_bucket{archive="planet",handler="tile",status="canceled",le="+Inf"} 128
pmtiles_request_duration_seconds_sum{archive="planet",handler="tile",status="canceled"} 4.8165444530000014
pmtiles_request_duration_seconds_count{archive="planet",handler="tile",status="canceled"} 128
# HELP pmtiles_requests_total Overall number of requests to the service
# TYPE pmtiles_requests_total counter
pmtiles_requests_total{archive="",handler="CONNECT",status="405"} 1
pmtiles_requests_total{archive="",handler="OPTIONS",status="204"} 253
pmtiles_requests_total{archive="",handler="POST",status="405"} 1
pmtiles_requests_total{archive="",handler="tile",status="404"} 47
pmtiles_requests_total{archive="planet",handler="tile",status="200"} 64
pmtiles_requests_total{archive="planet",handler="tile",status="304"} 43
pmtiles_requests_total{archive="planet",handler="tile",status="canceled"} 128
# HELP pmtiles_response_size_bytes Overall response size in bytes
# TYPE pmtiles_response_size_bytes histogram
pmtiles_response_size_bytes_bucket{archive="",handler="tile",status="404",le="1024"} 47
pmtiles_response_size_bytes_bucket{archive="",handler="tile",status="404",le="5120"} 47
pmtiles_response_size_bytes_bucket{archive="",handler="tile",status="404",le="10240"} 47
pmtiles_response_size_bytes_bucket{archive="",handler="tile",status="404",le="25600"} 47
pmtiles_response_size_bytes_bucket{archive="",handler="tile",status="404",le="51200"} 47
pmtiles_response_size_bytes_bucket{archive="",handler="tile",status="404",le="102400"} 47
pmtiles_response_size_bytes_bucket{archive="",handler="tile",status="404",le="256000"} 47
pmtiles_response_size_bytes_bucket{archive="",handler="tile",status="404",le="512000"} 47
pmtiles_response_size_bytes_bucket{archive="",handler="tile",status="404",le="1.048576e+06"} 47
pmtiles_response_size_bytes_bucket{archive="",handler="tile",status="404",le="+Inf"} 47
pmtiles_response_size_bytes_sum{archive="",handler="tile",status="404"} 799
pmtiles_response_size_bytes_count{archive="",handler="tile",status="404"} 47
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="200",le="1024"} 2
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="200",le="5120"} 6
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="200",le="10240"} 11
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="200",le="25600"} 18
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="200",le="51200"} 33
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="200",le="102400"} 55
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="200",le="256000"} 64
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="200",le="512000"} 64
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="200",le="1.048576e+06"} 64
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="200",le="+Inf"} 64
pmtiles_response_size_bytes_sum{archive="planet",handler="tile",status="200"} 3.403524e+06
pmtiles_response_size_bytes_count{archive="planet",handler="tile",status="200"} 64
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="304",le="1024"} 0
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="304",le="5120"} 0
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="304",le="10240"} 1
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="304",le="25600"} 6
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="304",le="51200"} 18
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="304",le="102400"} 34
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="304",le="256000"} 43
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="304",le="512000"} 43
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="304",le="1.048576e+06"} 43
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="304",le="+Inf"} 43
pmtiles_response_size_bytes_sum{archive="planet",handler="tile",status="304"} 2.787782e+06
pmtiles_response_size_bytes_count{archive="planet",handler="tile",status="304"} 43
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="canceled",le="1024"} 127
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="canceled",le="5120"} 127
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="canceled",le="10240"} 127
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="canceled",le="25600"} 127
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="canceled",le="51200"} 127
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="canceled",le="102400"} 128
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="canceled",le="256000"} 128
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="canceled",le="512000"} 128
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="canceled",le="1.048576e+06"} 128
pmtiles_response_size_bytes_bucket{archive="planet",handler="tile",status="canceled",le="+Inf"} 128
pmtiles_response_size_bytes_sum{archive="planet",handler="tile",status="canceled"} 102841
pmtiles_response_size_bytes_count{archive="planet",handler="tile",status="canceled"} 128
```

</details>