### PR TITLE
Add support for --tile-compression on convert operations.

### DIFF
--- a/pmtiles/convert_test.go
+++ b/pmtiles/convert_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestResolver(t *testing.T) {
-	resolver := newResolver(true, true)
+	resolver := newResolver(true, true, Gzip)
 	resolver.AddTileIsNew(1, []byte{0x1, 0x2})
 	assert.Equal(t, 1, len(resolver.Entries))
 	resolver.AddTileIsNew(2, []byte{0x1, 0x3})

--- a/pmtiles/server_test.go
+++ b/pmtiles/server_test.go
@@ -56,7 +56,7 @@ func fakeArchive(t *testing.T, header HeaderV3, metadata map[string]interface{},
 		keys = append(keys, id)
 	}
 	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
-	resolver := newResolver(false, false)
+	resolver := newResolver(false, false, Gzip)
 	tileDataBytes := make([]byte, 0)
 	for _, id := range keys {
 		tileBytes := byTileID[id]


### PR DESCRIPTION
This adds the first step towards supporting additional tile compressions in the convert tool.

If a tile-compression flag is passed, then any compression other than gzip is passed-through as-is, assumed to be valid. Also sets the header compression flag as expected.