### PR TITLE
PMTiles Show: Generate an encoded URL that will quickly take you to PMTiles.io

### DIFF
--- a/pmtiles/show.go
+++ b/pmtiles/show.go
@@ -113,7 +113,7 @@ func Show(_ *log.Logger, output io.Writer, bucketURL string, key string, showHea
 			}
 
 			if strings.HasPrefix(bucketURL, "http") {
-				fmt.Println("xray: https://pmtiles.io/#url=" + url.QueryEscape(bucketURL+"/"+key))
+				fmt.Println("web viewer: https://pmtiles.io/#url=" + url.QueryEscape(bucketURL+"/"+key))
 			}
 		}
 	} else {

--- a/pmtiles/show.go
+++ b/pmtiles/show.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"strings"
 
 	// "github.com/dustin/go-humanize"
 	"io"
@@ -108,6 +110,10 @@ func Show(_ *log.Logger, output io.Writer, bucketURL string, key string, showHea
 				default:
 					fmt.Println(k, "<object...>")
 				}
+			}
+
+			if strings.HasPrefix(bucketURL, "http") {
+				fmt.Println("xray: https://pmtiles.io/#url=" + url.QueryEscape(bucketURL+"/"+key))
 			}
 		}
 	} else {

--- a/pmtiles/show.go
+++ b/pmtiles/show.go
@@ -112,7 +112,7 @@ func Show(_ *log.Logger, output io.Writer, bucketURL string, key string, showHea
 				}
 			}
 
-			if strings.HasPrefix(bucketURL, "http") {
+			if strings.HasPrefix(bucketURL, "https://") {
 				fmt.Println("web viewer: https://pmtiles.io/#url=" + url.QueryEscape(bucketURL+"/"+key))
 			}
 		}


### PR DESCRIPTION
#### Minor feature enhancement to `pmtiles show`

* `pmtiles show` now generates an encoded URL that will quickly take you to [PMTiles.io](http://pmtiles.io/) with your archive passed in.
* Perfect for 1-click links for inspecting PMTiles.
* Easily clickable from Visual Studio code or on macOS use `open -a <browser_name>`
* Future ideas below.

---

#### Test on S3 compatible PMTile

```bash
# log an element "xray:"
pmtiles show https://demo-bucket.protomaps.com/v4.pmtiles
```

Result

* Output looks something like:

    pmtiles spec version: 3
    tile type: mvt
    ...
    xray: https://pmtiles.io/#url=https%3A%2F%2Fdemo-bucket.protomaps.com%2Fv4.pmtiles

---

#### Test on local PMTile

For the case of a local file, the "xray: " log element is disabled.

```bash
# Show works as before
pmtiles show pmtiles/fixtures/test_fixture_1.pmtiles
```

---
#### Future ideas with other `pmtiles` commands:

##### `tile`
- [ ] @bdon's idea from Slack:  "*allow `pmtiles tile` to link to the tile inspector*"
  * https://pmtiles.io/tile/#zxy=1/0/0&url=https%3A%2F%2Fdemo-bucket.protomaps.com%2Fv4.pmtiles

##### local file + `serve`
- [ ] `pmtiles show` for a local file:   "*Maybe provide a hint that the Go tool can also serve a folder*":  
  * `pmtiles serve pmtiles/fixtures`
- [ ]  `pmtiles serve` could also log a link to the locally servedTileJSON:  `https://pmtiles.io/#url=http%3A%2F%2Flocalhost%3A8080%2Ftest_fixture_1.json`
  * Works with:  `pmtiles serve pmtiles/fixtures --public-url=http://localhost:8080`