### PR TITLE
CLI Quiet Mode and Custom Progress Writer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ go-pmtiles
 *.json
 *.geojson
 *.tsv.gz
+examples/*.pmtiles

--- a/examples/custom_progress.go
+++ b/examples/custom_progress.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/protomaps/go-pmtiles/pmtiles"
+)
+
+// CloudProgress represents a custom progress writer
+type CloudProgress struct {
+	serviceName string
+}
+
+// CustomProgress tracks progress for individual operations
+type CustomProgress struct {
+	serviceName string
+	operation   string
+	total       int64
+	current     int64
+	startTime   time.Time
+}
+
+// NewCountProgress creates a progress tracker for count-based operations
+func (c *CloudProgress) NewCountProgress(total int64, description string) pmtiles.Progress {
+	fmt.Printf("[%s] Starting operation: %s (total items: %d)\n", c.serviceName, description, total)
+	return &CustomProgress{
+		serviceName: c.serviceName,
+		operation:   description,
+		total:       total,
+		current:     0,
+		startTime:   time.Now(),
+	}
+}
+
+// NewBytesProgress creates a progress tracker for byte-based operations
+func (c *CloudProgress) NewBytesProgress(total int64, description string) pmtiles.Progress {
+	fmt.Printf("[%s] Starting operation: %s (total bytes: %s)\n",
+		c.serviceName, description, formatBytes(total))
+	return &CustomProgress{
+		serviceName: c.serviceName,
+		operation:   description,
+		total:       total,
+		current:     0,
+		startTime:   time.Now(),
+	}
+}
+
+// Write implements io.Writer for byte-based progress tracking
+func (p *CustomProgress) Write(data []byte) (int, error) {
+	p.current += int64(len(data))
+	p.reportProgress()
+
+	// Here you would typically send the progress update to some external service
+
+	return len(data), nil
+}
+
+// Add increments the progress counter for count-based operations
+func (p *CustomProgress) Add(num int) {
+	p.current += int64(num)
+	p.reportProgress()
+
+	// Send progress update to outside service here if needed
+}
+
+// Close finalizes the progress tracking
+func (p *CustomProgress) Close() error {
+	duration := time.Since(p.startTime)
+	fmt.Printf("[%s] Completed: %s in %v\n", p.serviceName, p.operation, duration.Round(time.Millisecond))
+
+	// Send completion notification to outside service here if needed
+	return nil
+}
+
+// reportProgress displays current progress and could send updates to cloud services
+func (p *CustomProgress) reportProgress() {
+	if p.total <= 0 {
+		return
+	}
+
+	percentage := float64(p.current) / float64(p.total) * 100
+	elapsed := time.Since(p.startTime)
+
+	// Create a simple progress bar
+	barWidth := 30
+	filled := int(percentage / 100 * float64(barWidth))
+	bar := strings.Repeat("█", filled) + strings.Repeat("░", barWidth-filled)
+
+	if strings.Contains(p.operation, "bytes") || p.total > 1000 {
+		// Byte-based progress
+		fmt.Printf("[%s] %s: %.1f%% [%s] %s/%s (%.2fs)\n",
+			p.serviceName, p.operation, percentage, bar,
+			formatBytes(p.current), formatBytes(p.total), elapsed.Seconds())
+	} else {
+		// Count-based progress
+		fmt.Printf("[%s] %s: %.1f%% [%s] %d/%d items (%.2fs)\n",
+			p.serviceName, p.operation, percentage, bar,
+			p.current, p.total, elapsed.Seconds())
+	}
+}
+
+// formatBytes converts bytes to human-readable format
+func formatBytes(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}
+
+func main() {
+	// Custom progress writer for external services
+	fmt.Println("\nCustom Cloud Progress Writer:")
+	cloudProgress := &CloudProgress{serviceName: "Service"}
+	pmtiles.SetProgressWriter(cloudProgress)
+
+	// Simulate some progress operations
+	fmt.Println("\nSimulating PMTiles operations with custom progress reporting:")
+
+	// Simulate a count-based operation
+	progressCount := cloudProgress.NewCountProgress(100, "Processing tiles")
+	for i := 0; i < 100; i += 10 {
+		progressCount.Add(10)
+		time.Sleep(50 * time.Millisecond) // Simulate work
+	}
+	progressCount.Close()
+
+	// Simulate a bytes-based operation
+	progressBytes := cloudProgress.NewBytesProgress(1024*1024, "Uploading tiles")
+	data := make([]byte, 64*1024) // 64KB chunks
+	for i := 0; i < 16; i++ {
+		progressBytes.Write(data)
+		time.Sleep(30 * time.Millisecond) // Simulate upload time
+	}
+	progressBytes.Close()
+}

--- a/pmtiles/progress.go
+++ b/pmtiles/progress.go
@@ -1,0 +1,146 @@
+package pmtiles
+
+import (
+	"io"
+	"sync"
+
+	"github.com/schollz/progressbar/v3"
+)
+
+// ProgressWriter is an interface for progress reporting during pmtiles operations.
+// It supports both count-based and byte-based progress tracking.
+type ProgressWriter interface {
+	// NewCountProgress creates a progress tracker for count-based operations
+	NewCountProgress(total int64, description string) Progress
+	// NewBytesProgress creates a progress tracker for byte-based operations
+	NewBytesProgress(total int64, description string) Progress
+}
+
+// Progress represents an active progress tracker that can be updated and written to
+type Progress interface {
+	io.Writer
+	// Add increments the progress by the specified amount
+	Add(num int)
+	// Close finalizes the progress tracker
+	Close() error
+}
+
+var (
+	// Global progress writer, protected by mutex
+	progressWriterMu sync.RWMutex
+	progressWriter   ProgressWriter
+)
+
+func init() {
+	// Initialize with default progress writer
+	progressWriter = &defaultProgressWriter{}
+}
+
+// SetProgressWriter sets a custom progress writer for all pmtiles operations.
+// Pass nil to disable all progress reporting.
+func SetProgressWriter(pw ProgressWriter) {
+	progressWriterMu.Lock()
+	defer progressWriterMu.Unlock()
+	if pw == nil {
+		progressWriter = &quietProgressWriter{}
+	} else {
+		progressWriter = pw
+	}
+}
+
+// getProgressWriter returns the current progress writer
+func getProgressWriter() ProgressWriter {
+	progressWriterMu.RLock()
+	defer progressWriterMu.RUnlock()
+	return progressWriter
+}
+
+// SetQuietMode enables or disables quiet mode for all pmtiles operations.
+// When quiet mode is enabled, progress bars and verbose logging are suppressed.
+// This function is maintained for backward compatibility.
+func SetQuietMode(quiet bool) {
+	progressWriterMu.Lock()
+	defer progressWriterMu.Unlock()
+	quietMode = quiet
+	if quiet {
+		progressWriter = &quietProgressWriter{}
+	} else {
+		progressWriter = &defaultProgressWriter{}
+	}
+}
+
+// IsQuietMode returns the current quiet mode setting.
+func IsQuietMode() bool {
+	return quietMode
+}
+
+// defaultProgressWriter implements ProgressWriter using the schollz/progressbar library
+type defaultProgressWriter struct{}
+
+func (d *defaultProgressWriter) NewCountProgress(total int64, description string) Progress {
+	if quietMode {
+		return &quietProgress{}
+	}
+	bar := progressbar.Default(total, description)
+	return &progressBarWrapper{bar: bar}
+}
+
+func (d *defaultProgressWriter) NewBytesProgress(total int64, description string) Progress {
+	if quietMode {
+		return &quietProgress{}
+	}
+	bar := progressbar.DefaultBytes(total, description)
+	return &progressBarWrapper{bar: bar}
+}
+
+// progressBarWrapper wraps schollz/progressbar to implement our Progress interface
+type progressBarWrapper struct {
+	bar *progressbar.ProgressBar
+}
+
+func (p *progressBarWrapper) Write(data []byte) (int, error) {
+	if p.bar == nil {
+		return len(data), nil
+	}
+	return p.bar.Write(data)
+}
+
+func (p *progressBarWrapper) Add(num int) {
+	if p.bar != nil {
+		p.bar.Add(num)
+	}
+}
+
+func (p *progressBarWrapper) Close() error {
+	if p.bar != nil {
+		return p.bar.Close()
+	}
+	return nil
+}
+
+// quietProgressWriter implements ProgressWriter with no-op operations
+type quietProgressWriter struct{}
+
+func (q *quietProgressWriter) NewCountProgress(total int64, description string) Progress {
+	return &quietProgress{}
+}
+
+func (q *quietProgressWriter) NewBytesProgress(total int64, description string) Progress {
+	return &quietProgress{}
+}
+
+// quietProgress is a no-op implementation of Progress
+type quietProgress struct{}
+
+func (q *quietProgress) Write(data []byte) (int, error) {
+	return len(data), nil
+}
+
+func (q *quietProgress) Add(num int) {
+	// no-op - intentionally empty
+	_ = num // suppress unused parameter warning
+}
+
+func (q *quietProgress) Close() error {
+	return nil
+}

--- a/pmtiles/progress_test.go
+++ b/pmtiles/progress_test.go
@@ -1,0 +1,452 @@
+package pmtiles
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+)
+
+// Mock progress writer for testing
+type mockProgressWriter struct {
+	countProgressCalls []mockProgressCall
+	bytesProgressCalls []mockProgressCall
+	mu                 sync.Mutex
+}
+
+type mockProgressCall struct {
+	total       int64
+	description string
+}
+
+func (m *mockProgressWriter) NewCountProgress(total int64, description string) Progress {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.countProgressCalls = append(m.countProgressCalls, mockProgressCall{total, description})
+	return &mockProgress{total: total, description: description}
+}
+
+func (m *mockProgressWriter) NewBytesProgress(total int64, description string) Progress {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.bytesProgressCalls = append(m.bytesProgressCalls, mockProgressCall{total, description})
+	return &mockProgress{total: total, description: description}
+}
+
+func (m *mockProgressWriter) getCountProgressCalls() []mockProgressCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]mockProgressCall{}, m.countProgressCalls...)
+}
+
+func (m *mockProgressWriter) getBytesProgressCalls() []mockProgressCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]mockProgressCall{}, m.bytesProgressCalls...)
+}
+
+func (m *mockProgressWriter) reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.countProgressCalls = nil
+	m.bytesProgressCalls = nil
+}
+
+// Mock progress implementation
+type mockProgress struct {
+	total       int64
+	current     int64
+	description string
+	closed      bool
+	addCalls    []int
+	writeCalls  [][]byte
+	mu          sync.Mutex
+}
+
+func (p *mockProgress) Write(data []byte) (int, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.writeCalls = append(p.writeCalls, append([]byte{}, data...))
+	p.current += int64(len(data))
+	return len(data), nil
+}
+
+func (p *mockProgress) Add(num int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.addCalls = append(p.addCalls, num)
+	p.current += int64(num)
+}
+
+func (p *mockProgress) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.closed = true
+	return nil
+}
+
+func (p *mockProgress) getCurrent() int64 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.current
+}
+
+func (p *mockProgress) isClosed() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.closed
+}
+
+func (p *mockProgress) getAddCalls() []int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]int{}, p.addCalls...)
+}
+
+func (p *mockProgress) getWriteCalls() [][]byte {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	result := make([][]byte, len(p.writeCalls))
+	for i, call := range p.writeCalls {
+		result[i] = append([]byte{}, call...)
+	}
+	return result
+}
+
+// Helper function to reset progress writer state
+func resetProgressWriter() {
+	progressWriterMu.Lock()
+	defer progressWriterMu.Unlock()
+	progressWriter = &defaultProgressWriter{}
+	quietMode = false
+}
+
+func TestSetProgressWriter(t *testing.T) {
+	defer resetProgressWriter()
+
+	mock := &mockProgressWriter{}
+	SetProgressWriter(mock)
+
+	writer := getProgressWriter()
+	if writer != mock {
+		t.Errorf("Expected progress writer to be mock, got %T", writer)
+	}
+}
+
+func TestSetProgressWriterNil(t *testing.T) {
+	defer resetProgressWriter()
+
+	SetProgressWriter(nil)
+
+	writer := getProgressWriter()
+	if _, ok := writer.(*quietProgressWriter); !ok {
+		t.Errorf("Expected progress writer to be quietProgressWriter when set to nil, got %T", writer)
+	}
+}
+
+func TestSetQuietMode(t *testing.T) {
+	defer resetProgressWriter()
+
+	// Test enabling quiet mode
+	SetQuietMode(true)
+	if !IsQuietMode() {
+		t.Error("Expected IsQuietMode() to return true")
+	}
+	writer := getProgressWriter()
+	if _, ok := writer.(*quietProgressWriter); !ok {
+		t.Errorf("Expected progress writer to be quietProgressWriter in quiet mode, got %T", writer)
+	}
+
+	// Test disabling quiet mode
+	SetQuietMode(false)
+	if IsQuietMode() {
+		t.Error("Expected IsQuietMode() to return false")
+	}
+	writer = getProgressWriter()
+	if _, ok := writer.(*defaultProgressWriter); !ok {
+		t.Errorf("Expected progress writer to be defaultProgressWriter when quiet mode disabled, got %T", writer)
+	}
+}
+
+func TestDefaultProgressWriter(t *testing.T) {
+	defer resetProgressWriter()
+
+	// Test with quiet mode disabled
+	SetQuietMode(false)
+	writer := &defaultProgressWriter{}
+
+	// Test NewCountProgress
+	progress := writer.NewCountProgress(100, "test count")
+	if progress == nil {
+		t.Error("Expected non-nil progress from NewCountProgress")
+	}
+
+	// Test NewBytesProgress
+	progress = writer.NewBytesProgress(1024, "test bytes")
+	if progress == nil {
+		t.Error("Expected non-nil progress from NewBytesProgress")
+	}
+}
+
+func TestDefaultProgressWriterQuietMode(t *testing.T) {
+	defer resetProgressWriter()
+
+	// Test with quiet mode enabled
+	SetQuietMode(true)
+	writer := &defaultProgressWriter{}
+
+	// Test NewCountProgress in quiet mode
+	progress := writer.NewCountProgress(100, "test count")
+	if _, ok := progress.(*quietProgress); !ok {
+		t.Errorf("Expected quietProgress in quiet mode, got %T", progress)
+	}
+
+	// Test NewBytesProgress in quiet mode
+	progress = writer.NewBytesProgress(1024, "test bytes")
+	if _, ok := progress.(*quietProgress); !ok {
+		t.Errorf("Expected quietProgress in quiet mode, got %T", progress)
+	}
+}
+
+func TestProgressBarWrapper(t *testing.T) {
+	defer resetProgressWriter()
+
+	SetQuietMode(false)
+	writer := &defaultProgressWriter{}
+	progress := writer.NewCountProgress(100, "test")
+
+	// Test Write
+	data := []byte("test data")
+	n, err := progress.Write(data)
+	if err != nil {
+		t.Errorf("Unexpected error from Write: %v", err)
+	}
+	if n != len(data) {
+		t.Errorf("Expected Write to return %d, got %d", len(data), n)
+	}
+
+	// Test Add
+	progress.Add(10)
+
+	// Test Close
+	if err := progress.Close(); err != nil {
+		t.Errorf("Unexpected error from Close: %v", err)
+	}
+}
+
+func TestProgressBarWrapperNilBar(t *testing.T) {
+	wrapper := &progressBarWrapper{bar: nil}
+
+	// Test Write with nil bar
+	data := []byte("test")
+	n, err := wrapper.Write(data)
+	if err != nil {
+		t.Errorf("Unexpected error from Write with nil bar: %v", err)
+	}
+	if n != len(data) {
+		t.Errorf("Expected Write to return %d with nil bar, got %d", len(data), n)
+	}
+
+	// Test Add with nil bar (should not panic)
+	wrapper.Add(5)
+
+	// Test Close with nil bar
+	if err := wrapper.Close(); err != nil {
+		t.Errorf("Unexpected error from Close with nil bar: %v", err)
+	}
+}
+
+func TestQuietProgressWriter(t *testing.T) {
+	writer := &quietProgressWriter{}
+
+	// Test NewCountProgress
+	progress := writer.NewCountProgress(100, "test count")
+	if _, ok := progress.(*quietProgress); !ok {
+		t.Errorf("Expected quietProgress, got %T", progress)
+	}
+
+	// Test that Add method is callable on the returned progress (covers the missing line)
+	progress.Add(50)
+
+	// Test NewBytesProgress
+	progress = writer.NewBytesProgress(1024, "test bytes")
+	if _, ok := progress.(*quietProgress); !ok {
+		t.Errorf("Expected quietProgress, got %T", progress)
+	}
+
+	// Test that Add method is callable on this progress too
+	progress.Add(256)
+}
+
+func TestQuietProgress(t *testing.T) {
+	progress := &quietProgress{}
+
+	// Test Write
+	data := []byte("test data")
+	n, err := progress.Write(data)
+	if err != nil {
+		t.Errorf("Unexpected error from quiet Write: %v", err)
+	}
+	if n != len(data) {
+		t.Errorf("Expected quiet Write to return %d, got %d", len(data), n)
+	}
+
+	// Test Add (should not panic and be no-op)
+	progress.Add(10)
+	progress.Add(25)
+
+	// Test Close
+	if err := progress.Close(); err != nil {
+		t.Errorf("Unexpected error from quiet Close: %v", err)
+	}
+}
+
+func TestQuietProgressDirect(t *testing.T) {
+	// Directly test quietProgress.Add to ensure coverage
+	progress := &quietProgress{}
+	progress.Add(100) // This should execute the no-op function
+}
+
+func TestMockProgressWriter(t *testing.T) {
+	defer resetProgressWriter()
+
+	mock := &mockProgressWriter{}
+	SetProgressWriter(mock)
+
+	writer := getProgressWriter()
+
+	// Test NewCountProgress
+	progress1 := writer.NewCountProgress(100, "count test")
+	calls := mock.getCountProgressCalls()
+	if len(calls) != 1 {
+		t.Errorf("Expected 1 count progress call, got %d", len(calls))
+	}
+	if calls[0].total != 100 || calls[0].description != "count test" {
+		t.Errorf("Unexpected count progress call: total=%d, description=%s", calls[0].total, calls[0].description)
+	}
+
+	// Test NewBytesProgress
+	progress2 := writer.NewBytesProgress(1024, "bytes test")
+	byteCalls := mock.getBytesProgressCalls()
+	if len(byteCalls) != 1 {
+		t.Errorf("Expected 1 bytes progress call, got %d", len(byteCalls))
+	}
+	if byteCalls[0].total != 1024 || byteCalls[0].description != "bytes test" {
+		t.Errorf("Unexpected bytes progress call: total=%d, description=%s", byteCalls[0].total, byteCalls[0].description)
+	}
+
+	// Test progress operations
+	progress1.Add(25)
+	progress1.Add(35)
+	mockProgress1 := progress1.(*mockProgress)
+	addCalls := mockProgress1.getAddCalls()
+	if len(addCalls) != 2 || addCalls[0] != 25 || addCalls[1] != 35 {
+		t.Errorf("Unexpected Add calls: %v", addCalls)
+	}
+	if mockProgress1.getCurrent() != 60 {
+		t.Errorf("Expected current progress to be 60, got %d", mockProgress1.getCurrent())
+	}
+
+	// Test Write operations
+	data1 := []byte("hello")
+	data2 := []byte("world")
+	progress2.Write(data1)
+	progress2.Write(data2)
+	mockProgress2 := progress2.(*mockProgress)
+	writeCalls := mockProgress2.getWriteCalls()
+	if len(writeCalls) != 2 {
+		t.Errorf("Expected 2 write calls, got %d", len(writeCalls))
+	}
+	if !bytes.Equal(writeCalls[0], data1) || !bytes.Equal(writeCalls[1], data2) {
+		t.Errorf("Unexpected write calls: %v", writeCalls)
+	}
+	if mockProgress2.getCurrent() != 10 {
+		t.Errorf("Expected current progress to be 10, got %d", mockProgress2.getCurrent())
+	}
+
+	// Test Close
+	progress1.Close()
+	progress2.Close()
+	if !mockProgress1.isClosed() || !mockProgress2.isClosed() {
+		t.Error("Expected both progress instances to be closed")
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	defer resetProgressWriter()
+
+	mock := &mockProgressWriter{}
+
+	var wg sync.WaitGroup
+	numRoutines := 10
+
+	// Test concurrent SetProgressWriter calls
+	for i := 0; i < numRoutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			SetProgressWriter(mock)
+			_ = getProgressWriter()
+		}()
+	}
+
+	wg.Wait()
+
+	// Test concurrent progress creation
+	for i := 0; i < numRoutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			writer := getProgressWriter()
+			progress := writer.NewCountProgress(int64(idx*10), "concurrent test")
+			progress.Add(1)
+			progress.Close()
+		}(i)
+	}
+
+	wg.Wait()
+
+	calls := mock.getCountProgressCalls()
+	if len(calls) != numRoutines {
+		t.Errorf("Expected %d concurrent progress calls, got %d", numRoutines, len(calls))
+	}
+}
+
+func TestSetQuietModeAndCustomWriter(t *testing.T) {
+	defer resetProgressWriter()
+
+	mock := &mockProgressWriter{}
+
+	// Set custom writer first
+	SetProgressWriter(mock)
+	writer1 := getProgressWriter()
+	if writer1 != mock {
+		t.Error("Expected custom writer to be set")
+	}
+
+	// SetQuietMode should override custom writer
+	SetQuietMode(true)
+	writer2 := getProgressWriter()
+	if _, ok := writer2.(*quietProgressWriter); !ok {
+		t.Errorf("Expected quiet writer after SetQuietMode(true), got %T", writer2)
+	}
+	if !IsQuietMode() {
+		t.Error("Expected IsQuietMode() to return true")
+	}
+
+	// SetQuietMode(false) should restore default writer, not custom
+	SetQuietMode(false)
+	writer3 := getProgressWriter()
+	if _, ok := writer3.(*defaultProgressWriter); !ok {
+		t.Errorf("Expected default writer after SetQuietMode(false), got %T", writer3)
+	}
+	if IsQuietMode() {
+		t.Error("Expected IsQuietMode() to return false")
+	}
+
+	// Setting custom writer again should work
+	SetProgressWriter(mock)
+	writer4 := getProgressWriter()
+	if writer4 != mock {
+		t.Error("Expected custom writer to be set again")
+	}
+}


### PR DESCRIPTION
This PR adds support for custom progress writers, allowing consumers of the Go package to implement their own progress reporting while maintaining full backward compatibility.

A new (global) `--quiet` flag that will silence verbose output as discussed in https://github.com/protomaps/go-pmtiles/issues/117

One of my use-cases is to use the `go-pmtiles` package in an automated extract generating service. Right now I have some hacky code to parse the ASCII progressbar and convert that into a data structure that I can use to monitor and track extract progress.

### API Changes

#### New Public Functions
```go
// Set custom progress writer (nil disables progress)
pmtiles.SetProgressWriter(writer ProgressWriter)

// Interfaces for custom implementations
type ProgressWriter interface {
    NewCountProgress(total int64, description string) Progress
    NewBytesProgress(total int64, description string) Progress
}

type Progress interface {
    io.Writer
    Add(num int)
    Close() error
}

// Set quiet mode to reduce verbose output
pmtiles.SetQuietMode(true)
```

### Breaking Changes
**None.** This is purely additive - all existing code continues to work unchanged.

### Future work
https://github.com/protomaps/go-pmtiles/issues/117 also mentions `slog` which would be a nice change, however to implement this cleanly the public APIs would need to change from accepting an `log.Logger` to an `slog.Logger`. I chose not to include that in this PR to avoid making any breaking public API changes. There are ways to wrap and override `log.Logger` to not break the API, but I didn't want to go down that (messy) path without maintainer encouragement.

Overall there's a lot of CLI-like logic that could be pulled out of `pmtiles/` into the `main.go` CLI that would improve the `go-pmtiles` package ergonomics. The progress writer felt like a good place to start. The next one that would be useful to me is the `Show()` API, to programmatically get a struct of metadata.