### PR TITLE
Fix addressed tiles calculation

### DIFF
--- a/pmtiles/convert.go
+++ b/pmtiles/convert.go
@@ -46,7 +46,7 @@ func (r *resolver) NumContents() uint64 {
 
 // must be called in increasing tile_id order, uniquely
 func (r *resolver) AddTileIsNew(tileID uint64, data []byte, runLength uint32) (bool, []byte) {
-	r.AddressedTiles++
+	r.AddressedTiles += uint64(runLength)
 	var found offsetLen
 	var ok bool
 	var sumString string


### PR DESCRIPTION
The addressed tiles is the sum of all tile runlengths. Compare with pmtiles/verify.go:112.

Without this fix clustering will result in invalid pmtiles containers with larger maps.
I didn't add a test because that would increase the test runtime signifficantly.