### PR TITLE
Set Content-Length for tile responses (fixes chunked encoding for gzipped tiles)

### DIFF
--- a/pmtiles/server.go
+++ b/pmtiles/server.go
@@ -526,6 +526,8 @@ func (server *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) int {
 		w.Header().Set(k, v)
 	}
 	if statusCode == 200 {
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+
 		lrw := &loggingResponseWriter{w, 200}
 		// handle if-match, if-none-match request headers based on response etag
 		http.ServeContent(

--- a/pmtiles/server_test.go
+++ b/pmtiles/server_test.go
@@ -438,3 +438,25 @@ func TestCorsOptions(t *testing.T) {
 	assert.Equal(t, 204, res.Code)
 	assert.Equal(t, "*", res.Header().Get("Access-Control-Allow-Origin"))
 }
+
+func TestServeHTTP_PreservesContentLengthForGzipTiles(t *testing.T) {
+	mockBucket, server := newServer(t)
+	header := HeaderV3{
+		TileType: Mvt,
+	}
+
+	tileBytes := []byte{9, 8, 7, 6}
+	mockBucket.items["archive.pmtiles"] = fakeArchive(header, map[string]interface{}{}, map[Zxy][]byte{
+		{0, 0, 0}: tileBytes,
+	}, false, Gzip)
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/archive/0/0/0.mvt", nil)
+
+	server.ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+	assert.Equal(t, tileBytes, res.Body.Bytes())
+
+	assert.Equal(t, "4", res.Header().Get("Content-Length"))
+}


### PR DESCRIPTION
This PR sets the `Content-Length` header for tile responses. Normally `ServeContent` would set the `Content-Length` header, but a commit in the `net/http` package 3 years ago changed that for responses with `Content-Encoding` set.

But for pmtiles, the content is already gzipped, and we are just passing it, so not setting `Content-Length` doesn't make sense for us, especially that it breaks things like Cloudflare CDN which relies on `Content-Length` header being present to cache anything in its reserve.

- Cloudflare CDN architecture: https://developers.cloudflare.com/reference-architecture/architectures/cdn/#introducing-the-cloudflare-cdn:~:text=The%20Content%2DLength%20header%20must%20be%20used%20in%20the%20response%20header.
- Go commit introducing the change: https://github.com/golang/go/commit/fdc21f3eafe94490e55e0bf018490b3aa9ba2383

Diff:
https://github.com/golang/go/blob/master/src/net/http/fs.go#L399-L426