### PR TITLE
extract: add antimeridian support

### DIFF
--- a/pmtiles/extract.go
+++ b/pmtiles/extract.go
@@ -310,6 +310,7 @@ func Extract(ctx context.Context, logger *log.Logger, bucketURL string, key stri
 		}
 
 		var multipolygon orb.MultiPolygon
+		var centerLon, centerLat float64
 
 		if regionFile != "" {
 			dat, _ := ioutil.ReadFile(regionFile)
@@ -319,12 +320,8 @@ func Extract(ctx context.Context, logger *log.Logger, bucketURL string, key stri
 			}
 
 			bound := multipolygon.Bound()
-			header.MinLonE7 = int32(bound.Left() * 10000000)
-			header.MinLatE7 = int32(bound.Bottom() * 10000000)
-			header.MaxLonE7 = int32(bound.Right() * 10000000)
-			header.MaxLatE7 = int32(bound.Top() * 10000000)
-			header.CenterLonE7 = int32(bound.Center().X() * 10000000)
-			header.CenterLatE7 = int32(bound.Center().Y() * 10000000)
+			centerLon = bound.Center().X()
+			centerLat = bound.Center().Y()
 		} else {
 			parts := strings.Split(bbox, ",")
 			minLon, err := strconv.ParseFloat(parts[0], 64)
@@ -346,21 +343,23 @@ func Extract(ctx context.Context, logger *log.Logger, bucketURL string, key stri
 
 			multipolygon = bboxToMultiPolygon(minLon, minLat, maxLon, maxLat)
 
-			header.MinLonE7 = int32(minLon * 10000000)
-			header.MinLatE7 = int32(minLat * 10000000)
-			header.MaxLonE7 = int32(maxLon * 10000000)
-			header.MaxLatE7 = int32(maxLat * 10000000)
-
-			centerLon := (minLon + maxLon) / 2
+			centerLon = (minLon + maxLon) / 2
 			if minLon > maxLon {
 				centerLon = (minLon + maxLon + 360) / 2
 				if centerLon > 180 {
 					centerLon -= 360
 				}
 			}
-			header.CenterLonE7 = int32(centerLon * 10000000)
-			header.CenterLatE7 = int32((minLat + maxLat) / 2 * 10000000)
+			centerLat = (minLat + maxLat) / 2
 		}
+
+		bound := multipolygon.Bound()
+		header.MinLonE7 = int32(bound.Left() * 10000000)
+		header.MinLatE7 = int32(bound.Bottom() * 10000000)
+		header.MaxLonE7 = int32(bound.Right() * 10000000)
+		header.MaxLatE7 = int32(bound.Top() * 10000000)
+		header.CenterLonE7 = int32(centerLon * 10000000)
+		header.CenterLatE7 = int32(centerLat * 10000000)
 
 		// 2. construct a relevance bitmap
 		boundarySet, interiorSet := bitmapMultiPolygon(uint8(maxzoom), multipolygon)

--- a/pmtiles/extract.go
+++ b/pmtiles/extract.go
@@ -15,6 +15,8 @@ import (
 	"math"
 	"os"
 	"sort"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -312,32 +314,59 @@ func Extract(ctx context.Context, logger *log.Logger, bucketURL string, key stri
 		if regionFile != "" {
 			dat, _ := ioutil.ReadFile(regionFile)
 			multipolygon, err = UnmarshalRegion(dat)
+			if err != nil {
+				return err
+			}
 
-			if err != nil {
-				return err
-			}
+			bound := multipolygon.Bound()
+			header.MinLonE7 = int32(bound.Left() * 10000000)
+			header.MinLatE7 = int32(bound.Bottom() * 10000000)
+			header.MaxLonE7 = int32(bound.Right() * 10000000)
+			header.MaxLatE7 = int32(bound.Top() * 10000000)
+			header.CenterLonE7 = int32(bound.Center().X() * 10000000)
+			header.CenterLatE7 = int32(bound.Center().Y() * 10000000)
 		} else {
-			multipolygon, err = BboxRegion(bbox)
+			parts := strings.Split(bbox, ",")
+			minLon, err := strconv.ParseFloat(parts[0], 64)
 			if err != nil {
-				return err
+				return fmt.Errorf("invalid bbox: %w", err)
 			}
+			minLat, err := strconv.ParseFloat(parts[1], 64)
+			if err != nil {
+				return fmt.Errorf("invalid bbox: %w", err)
+			}
+			maxLon, err := strconv.ParseFloat(parts[2], 64)
+			if err != nil {
+				return fmt.Errorf("invalid bbox: %w", err)
+			}
+			maxLat, err := strconv.ParseFloat(parts[3], 64)
+			if err != nil {
+				return fmt.Errorf("invalid bbox: %w", err)
+			}
+
+			multipolygon = bboxToMultiPolygon(minLon, minLat, maxLon, maxLat)
+
+			header.MinLonE7 = int32(minLon * 10000000)
+			header.MinLatE7 = int32(minLat * 10000000)
+			header.MaxLonE7 = int32(maxLon * 10000000)
+			header.MaxLatE7 = int32(maxLat * 10000000)
+
+			centerLon := (minLon + maxLon) / 2
+			if minLon > maxLon {
+				centerLon = (minLon + maxLon + 360) / 2
+				if centerLon > 180 {
+					centerLon -= 360
+				}
+			}
+			header.CenterLonE7 = int32(centerLon * 10000000)
+			header.CenterLatE7 = int32((minLat + maxLat) / 2 * 10000000)
 		}
 
 		// 2. construct a relevance bitmap
-
-		bound := multipolygon.Bound()
-
 		boundarySet, interiorSet := bitmapMultiPolygon(uint8(maxzoom), multipolygon)
 		relevantSet = boundarySet
 		relevantSet.Or(interiorSet)
 		generalizeOr(relevantSet, uint8(minzoom))
-
-		header.MinLonE7 = int32(bound.Left() * 10000000)
-		header.MinLatE7 = int32(bound.Bottom() * 10000000)
-		header.MaxLonE7 = int32(bound.Right() * 10000000)
-		header.MaxLatE7 = int32(bound.Top() * 10000000)
-		header.CenterLonE7 = int32(bound.Center().X() * 10000000)
-		header.CenterLatE7 = int32(bound.Center().Y() * 10000000)
 	} else {
 		relevantSet = roaring64.New()
 		relevantSet.AddRange(ZxyToID(uint8(minzoom), 0, 0), ZxyToID(uint8(maxzoom)+1, 0, 0))

--- a/pmtiles/region.go
+++ b/pmtiles/region.go
@@ -8,6 +8,16 @@ import (
 	"strings"
 )
 
+func bboxToMultiPolygon(minLon, minLat, maxLon, maxLat float64) orb.MultiPolygon {
+	if minLon > maxLon {
+		return orb.MultiPolygon{
+			{{{minLon, maxLat}, {180, maxLat}, {180, minLat}, {minLon, minLat}, {minLon, maxLat}}},
+			{{{-180, maxLat}, {maxLon, maxLat}, {maxLon, minLat}, {-180, minLat}, {-180, maxLat}}},
+		}
+	}
+	return orb.MultiPolygon{{{{minLon, maxLat}, {maxLon, maxLat}, {maxLon, minLat}, {minLon, minLat}, {minLon, maxLat}}}}
+}
+
 // BboxRegion parses a bbox string into an orb.MultiPolygon region.
 func BboxRegion(bbox string) (orb.MultiPolygon, error) {
 	parts := strings.Split(bbox, ",")
@@ -27,7 +37,7 @@ func BboxRegion(bbox string) (orb.MultiPolygon, error) {
 	if err != nil {
 		return nil, err
 	}
-	return orb.MultiPolygon{{{{minLon, maxLat}, {maxLon, maxLat}, {maxLon, minLat}, {minLon, minLat}, {minLon, maxLat}}}}, nil
+	return bboxToMultiPolygon(minLon, minLat, maxLon, maxLat), nil
 }
 
 // UnmarshalRegion parses JSON bytes into an orb.MultiPolygon region.

--- a/pmtiles/region_test.go
+++ b/pmtiles/region_test.go
@@ -1,6 +1,7 @@
 package pmtiles
 
 import (
+	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -12,6 +13,24 @@ func TestBboxRegion(t *testing.T) {
 	assert.Equal(t, 52.304934, result[0][0][0][1])
 	assert.Equal(t, 1.097501, result[0][0][2][0])
 	assert.Equal(t, 50.680367, result[0][0][2][1])
+}
+
+func TestBboxRegionAntimeridianCrossing(t *testing.T) {
+	result, err := BboxRegion("170,-10,-170,10")
+	assert.Nil(t, err)
+	assert.Equal(t, orb.MultiPolygon{
+		{{{170, 10}, {180, 10}, {180, -10}, {170, -10}, {170, 10}}},
+		{{{-180, 10}, {-170, 10}, {-170, -10}, {-180, -10}, {-180, 10}}},
+	}, result)
+}
+
+func TestBboxRegionAntimeridianCrossingRingOrder(t *testing.T) {
+	result, err := BboxRegion("179.5,-5,-179.5,5")
+	assert.Nil(t, err)
+	assert.Equal(t, orb.MultiPolygon{
+		{{{179.5, 5}, {180, 5}, {180, -5}, {179.5, -5}, {179.5, 5}}},
+		{{{-180, 5}, {-179.5, 5}, {-179.5, -5}, {-180, -5}, {-180, 5}}},
+	}, result)
 }
 
 func TestRawPolygonRegion(t *testing.T) {

--- a/pmtiles/verify.go
+++ b/pmtiles/verify.go
@@ -162,7 +162,7 @@ func Verify(logger *log.Logger, file string) error {
 		return fmt.Errorf("invalid: header CenterZoom=%v not within MinZoom/MaxZoom", header.CenterZoom)
 	}
 
-	if header.MinLonE7 == header.MaxLonE7 || header.MinLatE7 >= header.MaxLatE7 {
+	if header.MinLonE7 >= header.MaxLonE7 || header.MinLatE7 >= header.MaxLatE7 {
 		return fmt.Errorf("Invalid: bounds has area <= 0: clients may not display tiles correctly")
 	}
 

--- a/pmtiles/verify.go
+++ b/pmtiles/verify.go
@@ -162,7 +162,7 @@ func Verify(logger *log.Logger, file string) error {
 		return fmt.Errorf("invalid: header CenterZoom=%v not within MinZoom/MaxZoom", header.CenterZoom)
 	}
 
-	if header.MinLonE7 >= header.MaxLonE7 || header.MinLatE7 >= header.MaxLatE7 {
+	if header.MinLonE7 == header.MaxLonE7 || header.MinLatE7 >= header.MaxLatE7 {
 		return fmt.Errorf("Invalid: bounds has area <= 0: clients may not display tiles correctly")
 	}
 


### PR DESCRIPTION
```sh
./go-pmtiles-before extract Fiji.pmtiles /tmp/before.pmtiles --bbox="176,-19,-178,-16"
```

Before (5MB--missing some data): 
[before.zip](https://github.com/user-attachments/files/29531315/before.zip) (rename to before.pmtiles)

```
bounds: (long: -178.000000, lat: -19.000000) (long: 176.000000, lat: -16.000000)
center: (long: -1.000000, lat: -17.500000)
tile entries count: 28
```

---

After (15MB): [after.zip](https://github.com/user-attachments/files/29531308/after.zip) (rename to after.pmtiles)

```
bounds: (long: -180.000000, lat: -19.000000) (long: 180.000000, lat: -16.000000)
center: (long: 179.000000, lat: -17.500000)
tile entries count: 6
```

(There's no way to represent a antimeridian-crossing range in standard TileJSON [west, south, east, north] without either west > east (which MapLibre rejects) or full-world bounds. ie. -180, 180 is the more correct extent: the data covers 176 to 180 and -180 to -178)

---

Screenshots:

Before: (looks like the current behavior is to not include 176 to 180)

<img width="1592" height="969" alt="Screenshot 2026-06-30 at 21-36-30 PMTiles viewer" src="https://github.com/user-attachments/assets/dd50de05-9acb-4da1-8620-94adbcbb56af" />

After:

<img width="1592" height="969" alt="Screenshot 2026-06-30 at 21-36-53 PMTiles viewer" src="https://github.com/user-attachments/assets/cc507224-3c36-43f5-a014-954d7d36d26d" />
