### PR TITLE
Preallocate entries slice in DeserializeEntries to reduce allocations

### DIFF
--- a/pmtiles/directory.go
+++ b/pmtiles/directory.go
@@ -323,8 +323,6 @@ func SerializeEntries(entries []EntryV3, compression Compression) []byte {
 }
 
 func DeserializeEntries(data *bytes.Buffer, compression Compression) []EntryV3 {
-	entries := make([]EntryV3, 0)
-
 	var reader io.Reader
 
 	if compression == NoCompression {
@@ -337,6 +335,10 @@ func DeserializeEntries(data *bytes.Buffer, compression Compression) []EntryV3 {
 	byteReader := bufio.NewReader(reader)
 
 	numEntries, _ := binary.ReadUvarint(byteReader)
+
+	// Preallocate the entries slice to the known count so the append loops below
+	// do not repeatedly reallocate and copy the backing array as it grows.
+	entries := make([]EntryV3, 0, numEntries)
 
 	lastID := uint64(0)
 	for i := uint64(0); i < numEntries; i++ {


### PR DESCRIPTION
## Summary

`DeserializeEntries` reads the entry count from the directory stream, then builds the result with `make([]EntryV3, 0)` + `append`. Since the slice starts at zero capacity, `append` reallocates and copies the backing array as it grows. For a full-planet leaf directory (~62k entries) that's **27 reallocations**, each discarding the previous backing array as transient garbage.

The exact entry count is already known before the append loops, so this PR sizes the slice capacity to it up front: `make([]EntryV3, 0, numEntries)`. The decode logic is otherwise unchanged.

## Why it's safe

- **Contents/length identical.** Only the initial capacity hint changes; the varint reads and delta/run-length/offset math are untouched, so the returned `[]EntryV3` has the same elements, order, and `len()`. The slice still starts at length 0, so a truncated stream behaves exactly as before.
- **No caller relies on `cap()` or appends into the returned slice.** All call sites (`server.go`, `show.go`, `extract.go`, `IterateEntries`) consume the result read-only; the only `append` (`extract.go`) appends the result *into another* slice.
- **No new trust in `numEntries`.** The value already bounds the existing append loop, so this introduces no new assumption about untrusted input.

## Benchmark

Decoding a realistic 62,746-entry leaf directory (gzip), allocations measured with `-benchmem`:

```
before:  8,849,368 B/op   216 allocs/op
after:   1,579,005 B/op   190 allocs/op
```

**~82% fewer bytes allocated per decode, 26 fewer allocations**, with no change in decode time. The win scales with directory size and matters most for servers that decode leaf directories on the hot path for scattered tile requests.
